### PR TITLE
좋아요 API 수정 사항

### DIFF
--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -9,3 +9,10 @@ export const diaryExceptionMessage = {
   OWNER_ONLY_EDIT: '일기 작성자만 수정할 수 있습니다.',
   OWNER_ONLY_DELETE: '일기 작성자만 삭제할 수 있습니다.',
 };
+
+export const userExceptionMessage = {
+  EXIST_EMAIL: '해당하는 이메일은 이미 존재합니다.',
+  EXIST_USERNAME: '해당하는 유저이름이 이미 존재합니다.',
+  INCORRECT_LOGIN: '로그인 정보를 확인해주세요.',
+  DOES_NOT_EXIST_USER: '해당하는 유저가 존재하지 않습니다.',
+};

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -4,3 +4,8 @@ export const favoriteExceptionMessage = {
   DOES_NOT_REGISTER_FAVORITE:
     '접근한 계정으로 해당 게시물에 좋아요가 등록 되어있지 않아 좋아요 취소가 불가능합니다.',
 };
+
+export const diaryExceptionMessage = {
+  OWNER_ONLY_EDIT: '일기 작성자만 수정할 수 있습니다.',
+  OWNER_ONLY_DELETE: '일기 작성자만 삭제할 수 있습니다.',
+};

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -1,0 +1,6 @@
+export const favoriteExceptionMessage = {
+  DOES_NOT_EXIST_DIARY: '존재하지 않는 게시물입니다.',
+  ONLY_ONE_FAVORITE: '접근한 계정은 해당 게시물에 좋아요가 등록되어있습니다.',
+  DOES_NOT_REGISTER_FAVORITE:
+    '접근한 계정으로 해당 게시물에 좋아요가 등록 되어있지 않아 좋아요 취소가 불가능합니다.',
+};

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { diaryExceptionMessage } from 'src/constants/exceptionMessage';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { Repository } from 'typeorm';
 import { DiaryEntity } from './diaries.entity';
@@ -77,7 +78,7 @@ export class DiariesService {
     const writer = targetDiary.author;
 
     if (writer.id !== accessUser.id) {
-      throw new UnauthorizedException('일기 작성자만 수정이 가능합니다.');
+      throw new UnauthorizedException(diaryExceptionMessage.OWNER_ONLY_EDIT);
     }
 
     await this.diaryRepository.update(id, {
@@ -93,7 +94,7 @@ export class DiariesService {
     const writer = targetDiary.author;
 
     if (writer.id !== accessUser.id) {
-      throw new UnauthorizedException('일기 작성자만 삭제가 가능합니다.');
+      throw new UnauthorizedException(diaryExceptionMessage.OWNER_ONLY_DELETE);
     }
 
     await this.diaryRepository.softDelete(id);

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -22,6 +22,10 @@ export class FavoritesService {
       .where({ id: diaryId })
       .getOne();
 
+    if (!targetDiary) {
+      throw new BadRequestException('존재하지 않는 게시물입니다.');
+    }
+
     if (
       targetDiary.favorites
         .map((favorite) => favorite.author.id)
@@ -54,6 +58,10 @@ export class FavoritesService {
       .leftJoin('favorite.diary', 'diary')
       .where({ author: accessUser, diary: targetDiary })
       .getOne();
+
+    if (!targetDiary) {
+      throw new BadRequestException('존재하지 않는 게시물입니다.');
+    }
 
     if (!targetFavoriteInstance) {
       throw new BadRequestException(

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -51,7 +51,7 @@ export class FavoritesService {
     const targetFavoriteInstance = await this.favoriteRepository
       .createQueryBuilder('favorite')
       .leftJoin('favorite.author', 'author')
-      .leftJoinAndSelect('favorite.diary', 'diary')
+      .leftJoin('favorite.diary', 'diary')
       .where({ author: accessUser, diary: targetDiary })
       .getOne();
 

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -14,8 +14,7 @@ export class FavoritesService {
     private readonly diaryRepository: Repository<DiaryEntity>,
   ) {}
 
-  async create(diaryId: string, likedUser: UserDTO) {
-    // FIXME: targetUser로 변경
+  async create(diaryId: string, accessUser: UserDTO) {
     const targetDiary = await this.diaryRepository
       .createQueryBuilder('diary')
       .leftJoinAndSelect('diary.favorites', 'favorites')
@@ -26,7 +25,7 @@ export class FavoritesService {
     if (
       targetDiary.favorites
         .map((favorite) => favorite.author.id)
-        .includes(likedUser.id)
+        .includes(accessUser.id)
     ) {
       throw new BadRequestException(
         '한 개의 게시물에 한 번의 좋아요만 할 수 있습니다.',
@@ -35,7 +34,7 @@ export class FavoritesService {
 
     targetDiary.favoriteCount += 1;
     const newFavorite = await this.favoriteRepository.create({
-      author: likedUser,
+      author: accessUser,
       diary: targetDiary,
     });
 
@@ -47,13 +46,13 @@ export class FavoritesService {
     return newFavorite;
   }
 
-  async delete(diaryId: string, targetUser: UserDTO) {
+  async delete(diaryId: string, accessUser: UserDTO) {
     const targetDiary = await this.diaryRepository.findOneBy({ id: diaryId });
     const targetFavoriteInstance = await this.favoriteRepository
       .createQueryBuilder('favorite')
       .leftJoin('favorite.author', 'author')
       .leftJoinAndSelect('favorite.diary', 'diary')
-      .where({ author: targetUser, diary: targetDiary })
+      .where({ author: accessUser, diary: targetDiary })
       .getOne();
 
     targetDiary.favoriteCount -= 1;

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -15,7 +15,7 @@ export class FavoritesService {
     private readonly diaryRepository: Repository<DiaryEntity>,
   ) {}
 
-  async create(diaryId: string, accessUser: UserDTO) {
+  async create(diaryId: string, user: UserDTO) {
     const targetDiary = await this.diaryRepository
       .createQueryBuilder('diary')
       .leftJoinAndSelect('diary.favorites', 'favorites')
@@ -32,14 +32,14 @@ export class FavoritesService {
     if (
       targetDiary.favorites
         .map((favorite) => favorite.author.id)
-        .includes(accessUser.id)
+        .includes(user.id)
     ) {
       throw new BadRequestException(favoriteExceptionMessage.ONLY_ONE_FAVORITE);
     }
 
     targetDiary.favoriteCount += 1;
     const newFavorite = await this.favoriteRepository.create({
-      author: accessUser,
+      author: user,
       diary: targetDiary,
     });
 
@@ -51,13 +51,13 @@ export class FavoritesService {
     return newFavorite;
   }
 
-  async delete(diaryId: string, accessUser: UserDTO) {
+  async delete(diaryId: string, user: UserDTO) {
     const targetDiary = await this.diaryRepository.findOneBy({ id: diaryId });
     const targetFavoriteInstance = await this.favoriteRepository
       .createQueryBuilder('favorite')
       .leftJoin('favorite.author', 'author')
       .leftJoin('favorite.diary', 'diary')
-      .where({ author: accessUser, diary: targetDiary })
+      .where({ author: user, diary: targetDiary })
       .getOne();
 
     if (!targetDiary) {

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -55,6 +55,12 @@ export class FavoritesService {
       .where({ author: accessUser, diary: targetDiary })
       .getOne();
 
+    if (!targetFavoriteInstance) {
+      throw new BadRequestException(
+        '접근한 계정으로 해당 게시물에 좋아요가 등록 되어있지 않아 좋아요 취소가 불가능합니다.',
+      );
+    }
+
     targetDiary.favoriteCount -= 1;
 
     this.diaryRepository.save(targetDiary);

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { favoriteExceptionMessage } from 'src/constants/exceptionMessage';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { FavoriteEntity } from './favorites.entity';
@@ -23,7 +24,9 @@ export class FavoritesService {
       .getOne();
 
     if (!targetDiary) {
-      throw new BadRequestException('존재하지 않는 게시물입니다.');
+      throw new BadRequestException(
+        favoriteExceptionMessage.DOES_NOT_EXIST_DIARY,
+      );
     }
 
     if (
@@ -31,9 +34,7 @@ export class FavoritesService {
         .map((favorite) => favorite.author.id)
         .includes(accessUser.id)
     ) {
-      throw new BadRequestException(
-        '접근한 계정은 해당 게시물에 좋아요가 등록되어있습니다.',
-      );
+      throw new BadRequestException(favoriteExceptionMessage.ONLY_ONE_FAVORITE);
     }
 
     targetDiary.favoriteCount += 1;
@@ -60,12 +61,14 @@ export class FavoritesService {
       .getOne();
 
     if (!targetDiary) {
-      throw new BadRequestException('존재하지 않는 게시물입니다.');
+      throw new BadRequestException(
+        favoriteExceptionMessage.DOES_NOT_EXIST_DIARY,
+      );
     }
 
     if (!targetFavoriteInstance) {
       throw new BadRequestException(
-        '접근한 계정으로 해당 게시물에 좋아요가 등록 되어있지 않아 좋아요 취소가 불가능합니다.',
+        favoriteExceptionMessage.DOES_NOT_REGISTER_FAVORITE,
       );
     }
 

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -28,7 +28,7 @@ export class FavoritesService {
         .includes(accessUser.id)
     ) {
       throw new BadRequestException(
-        '한 개의 게시물에 한 번의 좋아요만 할 수 있습니다.',
+        '접근한 계정은 해당 게시물에 좋아요가 등록되어있습니다.',
       );
     }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -12,6 +12,7 @@ import { UserEmailDTO, UserJoinDTO } from './dto/user-join.dto';
 import { UserEntity } from './users.entity';
 import { UserLoginDTO } from './dto/user-login.dto';
 import { JwtService } from '@nestjs/jwt';
+import { userExceptionMessage } from 'src/constants/exceptionMessage';
 
 @Injectable()
 export class UsersService {
@@ -32,12 +33,12 @@ export class UsersService {
 
     const userByEmail = await this.usersRepository.findOneBy({ email });
     if (userByEmail) {
-      throw new UnauthorizedException('해당하는 이메일은 이미 존재합니다.');
+      throw new UnauthorizedException(userExceptionMessage.EXIST_EMAIL);
     }
 
     const userByUsername = await this.usersRepository.findOneBy({ username });
     if (userByUsername) {
-      throw new UnauthorizedException('해당하는 유저이름이 이미 존재합니다.');
+      throw new UnauthorizedException(userExceptionMessage.EXIST_USERNAME);
     }
 
     const hashedPassword = await bcrypt.hashSync(password, 10);
@@ -55,7 +56,7 @@ export class UsersService {
 
     const user = await this.usersRepository.findOneBy({ email });
     if (user) {
-      throw new UnauthorizedException('해당하는 이메일은 이미 존재합니다.');
+      throw new UnauthorizedException(userExceptionMessage.EXIST_EMAIL);
     }
 
     return { message: '사용가능한 이메일입니다.' };
@@ -67,7 +68,7 @@ export class UsersService {
     });
 
     if (user) {
-      throw new UnauthorizedException('해당하는 유저 이름이 이미 존재합니다.');
+      throw new UnauthorizedException(userExceptionMessage.EXIST_USERNAME);
     }
 
     return { message: '사용가능한 유저이름입니다.' };
@@ -78,7 +79,7 @@ export class UsersService {
     const user = await this.usersRepository.findOneBy({ email });
 
     if (!user || !(await bcrypt.compare(password, user.password))) {
-      throw new UnauthorizedException('로그인 정보를 확인해주세요.');
+      throw new UnauthorizedException(userExceptionMessage.INCORRECT_LOGIN);
     }
 
     try {
@@ -97,7 +98,7 @@ export class UsersService {
     const user = this.usersRepository.findOneBy({ id });
 
     if (!user) {
-      throw new UnauthorizedException('해당하는 유저가 존재하지 않습니다.');
+      throw new NotFoundException(userExceptionMessage.DOES_NOT_EXIST_USER);
     }
     return user;
   }
@@ -110,7 +111,7 @@ export class UsersService {
       .getOne();
 
     if (!user) {
-      throw new NotFoundException('해당 유저 정보를 찾을 수 없습니다.');
+      throw new NotFoundException(userExceptionMessage.DOES_NOT_EXIST_USER);
     }
     return user;
   }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #16 

<br />

## 🗒 작업 목록

- [x] 파라미터 변수명 변경
- [x] 좋아요 delete API query문 수정
- [x] 좋아요 delete API 예외처리 추가
- [x] 좋아요 create API 예외처리 문구 변경

<br />

## 🧐 PR Point

- 파라미터의 변수명이 직관적인가요??
- 좋아요 이력을 찾는 query문에서 author와 diary의 데이터는 불필요하여 `leftJoinAndSelect` query문에서 `leftJoin` query문으로 변경하여 where절에서만 author, diary 데이터를 참조하였습니다.

<br />

## 💥 Trouble Shooting

- 좋아요를 등록하지 않은 게시물에 좋아요 delete API 호출 시 500에러 발생으로 서버가 다운 되는 이슈 발생하였습니다.
- 좋아요 delete API에 해당 게시물에 좋아요를 등록하지 않은 유저가 좋아요 취소 요청을 보내는 경우 예외처리 로직을 추가하였습니다.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
