### PR TITLE
좋아요 api 코드 수정사항 반영

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,13 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn', // or "error"
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
   },
 };

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -187,7 +187,7 @@ export const responseExampleForDiary = {
 };
 
 export const responseExampleForFavorite = {
-  createFavorite: responseTemplate({
+  registerFavorite: responseTemplate({
     author: {
       id: 'd50d5458-dadf-4d29-b487-d64f75cca1d8',
       createdAt: '2023-03-01T08:37:09.283Z',
@@ -212,7 +212,7 @@ export const responseExampleForFavorite = {
     createdAt: '2023-03-01T08:37:20.062Z',
     updatedAt: '2023-03-01T08:37:20.062Z',
   }),
-  deleteFavorite: responseTemplate({
+  unregisterFavorite: responseTemplate({
     message: '취소 되었습니다.',
   }),
 };

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -188,29 +188,7 @@ export const responseExampleForDiary = {
 
 export const responseExampleForFavorite = {
   registerFavorite: responseTemplate({
-    author: {
-      id: 'd50d5458-dadf-4d29-b487-d64f75cca1d8',
-      createdAt: '2023-03-01T08:37:09.283Z',
-      updatedAt: '2023-03-01T08:37:09.283Z',
-      email: 'test@test6.com',
-      username: 'test6',
-      thumbnailUrl: 'http://127.0.0.1:5000',
-      isAgree: true,
-      isAdmin: false,
-    },
-    diary: {
-      id: '5528612e-2e34-478e-b300-235d27738cde',
-      createdAt: '2023-02-22T13:33:03.898Z',
-      updatedAt: '2023-03-01T08:35:53.473Z',
-      title: 'qweqwe',
-      content: '하하하 공부 열심히 해야되는데...ㅎㅎ',
-      imgUrl: null,
-      favoriteCount: 9,
-      commentCount: 0,
-    },
-    id: 'd5bee6d3-0d5d-4572-a1a0-bc31dcb4acc7',
-    createdAt: '2023-03-01T08:37:20.062Z',
-    updatedAt: '2023-03-01T08:37:20.062Z',
+    message: '좋아요가 등록되었습니다.',
   }),
   unregisterFavorite: responseTemplate({
     message: '취소 되었습니다.',
@@ -219,7 +197,7 @@ export const responseExampleForFavorite = {
 
 export const responseExampleForBookmark = {
   registerBookmark: responseTemplate({
-    message: '북마크가 등록되었습니다..',
+    message: '북마크가 등록되었습니다.',
   }),
   unregisterBookmark: responseTemplate({
     message: '취소 되었습니다.',

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -150,13 +150,13 @@ export class DiariesController {
     summary: '일기 좋아요 등록',
   })
   @ApiBearerAuth('access-token')
-  @ApiCreatedResponse(responseExampleForFavorite.createFavorite)
+  @ApiCreatedResponse(responseExampleForFavorite.registerFavorite)
   @UseGuards(JwtAuthGuard)
-  createFavorite(
+  registerFavorite(
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() currentUser: UserDTO,
   ) {
-    return this.favoritesService.create(id, currentUser);
+    return this.favoritesService.register(id, currentUser);
   }
 
   @Delete(':id/favorite')
@@ -164,13 +164,13 @@ export class DiariesController {
     summary: '일기 좋아요 취소',
   })
   @ApiBearerAuth('access-token')
-  @ApiCreatedResponse(responseExampleForFavorite.deleteFavorite)
+  @ApiCreatedResponse(responseExampleForFavorite.unregisterFavorite)
   @UseGuards(JwtAuthGuard)
-  deleteFavorite(
+  unregisterFavorite(
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() currentUser: UserDTO,
   ) {
-    return this.favoritesService.delete(id, currentUser);
+    return this.favoritesService.unregister(id, currentUser);
   }
 
   // 북마크 API

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -34,10 +34,10 @@ export class DiariesService {
   }
 
   generateCustomFieldForDiary(diary: DiaryEntity, accessUserId: string) {
-    const { author, favorites, bookmarks, deleteAt, ...otherInfo } = diary; // FIXME: nest의 classSerializerInterceptor로 처리할 수 있는 방법 고안하기
+    const { author, favorites, bookmarks, deleteAt: _, ...otherInfo } = diary; // FIXME: nest의 classSerializerInterceptor로 처리할 수 있는 방법 고안하기
 
     const isFavorite = favorites
-      .map((favorite) => favorite.author.id)
+      .map((favorite) => favorite.user.id)
       .includes(accessUserId);
 
     const isBookmark = bookmarks

--- a/src/favorities/favorites.entity.ts
+++ b/src/favorities/favorites.entity.ts
@@ -14,10 +14,10 @@ export class FavoriteEntity extends CommonEntity {
     onDelete: 'CASCADE',
   })
   @JoinColumn({
-    name: 'author_id',
+    name: 'user_id',
     referencedColumnName: 'id',
   })
-  author: UserEntity;
+  user: UserEntity;
 
   @ApiProperty()
   @ManyToOne(() => DiaryEntity, (diary: DiaryEntity) => diary.favorites, {

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -31,7 +31,7 @@ export class FavoritesService {
 
     if (
       targetDiary.favorites
-        .map((favorite) => favorite.author.id)
+        .map((favorite) => favorite.user.id)
         .includes(user.id)
     ) {
       throw new BadRequestException(favoriteExceptionMessage.ONLY_ONE_FAVORITE);
@@ -39,7 +39,7 @@ export class FavoritesService {
 
     targetDiary.favoriteCount += 1;
     const newFavorite = await this.favoriteRepository.create({
-      author: user,
+      user,
       diary: targetDiary,
     });
 

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -46,9 +46,7 @@ export class FavoritesService {
     await this.diaryRepository.save(targetDiary);
     await this.favoriteRepository.save(newFavorite);
 
-    delete newFavorite.diary.favorites;
-
-    return newFavorite;
+    return { message: '좋아요가 등록되었습니다.' };
   }
 
   async unregister(diaryId: string, user: UserDTO) {

--- a/src/favorities/favorites.service.ts
+++ b/src/favorities/favorites.service.ts
@@ -15,7 +15,7 @@ export class FavoritesService {
     private readonly diaryRepository: Repository<DiaryEntity>,
   ) {}
 
-  async create(diaryId: string, user: UserDTO) {
+  async register(diaryId: string, user: UserDTO) {
     const targetDiary = await this.diaryRepository
       .createQueryBuilder('diary')
       .leftJoinAndSelect('diary.favorites', 'favorites')
@@ -51,7 +51,7 @@ export class FavoritesService {
     return newFavorite;
   }
 
-  async delete(diaryId: string, user: UserDTO) {
+  async unregister(diaryId: string, user: UserDTO) {
     const targetDiary = await this.diaryRepository.findOneBy({ id: diaryId });
     const targetFavoriteInstance = await this.favoriteRepository
       .createQueryBuilder('favorite')

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -52,7 +52,7 @@ export class UserEntity extends CommonEntity {
   @ApiProperty()
   @OneToMany(
     () => FavoriteEntity,
-    (favorite: FavoriteEntity) => favorite.author,
+    (favorite: FavoriteEntity) => favorite.user,
     {
       cascade: true,
     },


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #27

<br />

## 🗒 작업 목록

- [x] 좋아요 테이블의 author -> user로 변경
    - 일기의 경우 author가 적절하지만 좋아요를 한 사용자의 경우 user가 의미적으로 더 맞다고 생각
- [x] 좋아요 controller, service 메소드 이름 변경 create/delete -> register/unregister
    - DB 측면으로 보면 좋아요 테이블에 create, delete가 발생하지만 의미적으로 본다면 register/unregister가 더 맞다고 생각
- [x] 좋아요 register api 성공 시 message 반환으로 수정

<br />

## 🧐 PR Point

- 기존에 작성해두었던 코드에서 의미상 더 적합한 변수들로 수정하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
