### PR TITLE
유저 정보 중 프론트에서 조회하지 않아도 될 필드 제거

### DIFF
--- a/src/users/dto/user-join.dto.ts
+++ b/src/users/dto/user-join.dto.ts
@@ -1,16 +1,21 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { UserEntity } from '../users.entity';
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsBoolean } from 'class-validator';
+import { Column } from 'typeorm';
 
 export class UserJoinDTO extends PickType(UserEntity, [
   'email',
   'username',
-  'isAgree',
 ] as const) {
   @ApiProperty()
   @IsString()
   @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
   password: string;
+
+  @ApiProperty()
+  @IsBoolean()
+  @Column({ type: 'boolean', nullable: false })
+  isAgree: boolean;
 }
 
 export class UserEmailDTO extends PickType(UserEntity, ['email'] as const) {}

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -1,17 +1,35 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
-import { IsBoolean, IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 import { BookmarkEntity } from 'src/bookmarks/bookmarks.entity';
-import { CommonEntity } from 'src/common/entities/common.entity';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { FavoriteEntity } from 'src/favorities/favorites.entity';
-import { Column, Entity, Index, OneToMany } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Index('email', ['email'], { unique: true })
 @Entity({
   name: 'USER',
 })
-export class UserEntity extends CommonEntity {
+export class UserEntity {
+  @IsUUID()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
   @ApiProperty()
   @IsEmail({}, { message: '올바른 이메일을 작성해주세요.' })
   @IsNotEmpty({ message: '이메일을 작성해주세요. ' })
@@ -42,6 +60,22 @@ export class UserEntity extends CommonEntity {
   @IsBoolean()
   @Column({ type: 'boolean', default: false })
   isAdmin: boolean;
+
+  @Exclude()
+  @CreateDateColumn({
+    type: 'timestamptz' /* timestamp with time zone */,
+  })
+  createdAt: Date;
+
+  @Exclude()
+  @UpdateDateColumn({
+    type: 'timestamptz' /* timestamp with time zone */,
+  })
+  updatedAt: Date;
+
+  @Exclude()
+  @DeleteDateColumn({ type: 'timestamptz' })
+  deleteAt?: Date | null;
 
   @ApiProperty()
   @OneToMany(() => DiaryEntity, (diary: DiaryEntity) => diary.author, {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #22

<br />

## 🗒 작업 목록

- [x] 기존 user entity에서 공용으로 사용하고 있던 entity 제거 후 별도의 필드 추가

<br />

## 🧐 PR Point

- 어떤 이유로 코드를 변경했나요?
- 리뷰어가 집중해야하는 포인트가 어디인가요?
- 해당 작업에서 주의 해야할 부분이 있나요?

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
