### PR TITLE
유저 별 일기 리스트 조회 기능 추가

### DIFF
--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -62,10 +62,7 @@ export const responseExampleForUser = {
     ],
   }),
   getCurrentUser: responseTemplate(userResponse),
-  getUserInfo: responseTemplate({
-    ...userResponse,
-    diaries: [diaryResponse],
-  }),
+  getUserInfo: responseTemplate(userResponse),
   getAllUsers: responseTemplate([userResponse]),
 };
 

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -21,6 +21,7 @@ import {
   ApiResponse,
   ApiOperation,
   ApiTags,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { BookmarksService } from 'src/bookmarks/bookmarks.service';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
@@ -65,9 +66,10 @@ export class DiariesController {
 
   @Get()
   @ApiOperation({
-    summary: '일기 전체 리스트 조회',
+    summary: '일기 리스트 조회',
   })
   @ApiBearerAuth('access-token')
+  @ApiQuery({ name: 'username', required: false })
   @ApiResponse(responseExampleForDiary.getDiaries)
   @UseGuards(JwtAuthGuard) // FIXME: 비로그인 상태 로직 생각하기
   getDiaries(

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseUUIDPipe,
   Post,
   Put,
+  Query,
   UploadedFile,
   UseFilters,
   UseGuards,
@@ -69,8 +70,11 @@ export class DiariesController {
   @ApiBearerAuth('access-token')
   @ApiResponse(responseExampleForDiary.getDiaries)
   @UseGuards(JwtAuthGuard) // FIXME: 비로그인 상태 로직 생각하기
-  getDiaries(@CurrentUser() currentUser: UserDTO) {
-    return this.diariesService.getAll(currentUser);
+  getDiaries(
+    @Query('username') username: string,
+    @CurrentUser() currentUser: UserDTO,
+  ) {
+    return this.diariesService.getDiaries(currentUser, username);
   }
 
   @Get('bookmark/:username')

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -85,6 +85,25 @@ export class DiariesService {
     return responseDiaries;
   }
 
+  async getDiaries(accessUser: UserDTO, diaryAuthorName?: string) {
+    const { selectDiaryInstance, tableAliasInfo } =
+      this.generateSelectDiaryInstance();
+
+    const diaries = !diaryAuthorName
+      ? await selectDiaryInstance.getMany()
+      : await selectDiaryInstance
+          .where(`${tableAliasInfo.diaryAuthor}.username = :username`, {
+            username: diaryAuthorName,
+          })
+          .getMany();
+
+    const responseDiaries = diaries.map((diary) => {
+      return this.generateCustomFieldForDiary(diary, accessUser.id);
+    });
+
+    return responseDiaries;
+  }
+
   async getOne(id: string, accessUser: UserDTO) {
     const { selectDiaryInstance, tableAliasInfo } =
       await this.generateSelectDiaryInstance();

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -106,7 +106,6 @@ export class UsersService {
   async findUserByUsername(username: string) {
     const user = await this.usersRepository
       .createQueryBuilder('user')
-      .leftJoinAndSelect('user.diaries', 'diaries')
       .where('user.username = :username', { username })
       .getOne();
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #31

<br />

## 🗒 작업 목록

- [x]  기존 유저 정보 조회에서 일기 정보를 반환하는 부분 제거
- [x]  유저별 일기 리스트 조회 API 개발
     - 기존의 일기 전체 리스트 조회에서 query string으로 유저 이름을 보내는 식으로 유저별 일기 리스트 조회를 구현하였습니다.
- [x]  swagger 최신화
     - 일기 리스트 조회 시 query string 넣을 수 있는 input 칸 추가
     - 유저 정보 조회 시 일기 리스트 정보 제외
- [x]  API 설계문서 최신화

<br />

## 🧐 PR Point

- 기존에 구현되었던 일기 리스트 조회에서는 유저별로 조회하는 기능이 없고, 유저 정보 조회 시 해당 유저가 작성한 일기 리스트를 조회할 수 있게 구현해두었습니다.
- 하지만, 위와 같이 구현한 경우 한 유저가 일기를 여러개 작성하게 된다면, 유저 정보 조회에서 일기에 대한 페이징 기능이 추가될 것으로 생각했습니다.
- 단일 책임 원칙을 지키기 위해 유저 정보 조회에서는 유저에 대한 정보만 다루고, 일기 조회는 일기 정보 조회에서 다루기 위해 해당 기능을 구현하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- <img width="1426" alt="image" src="https://user-images.githubusercontent.com/77317312/233757817-4e18bac1-29d6-400e-ae67-aaed14f508b6.png">

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
