### PR TITLE
일기 리스트 조회 페이징, 정렬 기능 구현

### DIFF
--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -74,14 +74,18 @@ export const responseExampleForDiary = {
     ...diaryResponse,
     author: userResponse,
   }),
-  getDiaries: responseTemplate([
-    {
-      ...diaryResponse,
-      isFavorite: 'boolean',
-      isBookmark: 'boolean',
-      author: userResponse,
-    },
-  ]),
+  getDiaries: responseTemplate({
+    diaries: [
+      {
+        ...diaryResponse,
+        isFavorite: 'boolean',
+        isBookmark: 'boolean',
+        author: userResponse,
+      },
+    ],
+    totalCount: 'number',
+    totalPage: 'number',
+  }),
   getDiary: responseTemplate({
     ...diaryResponse,
     isFavorite: 'boolean',

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -70,13 +70,18 @@ export class DiariesController {
   })
   @ApiBearerAuth('access-token')
   @ApiQuery({ name: 'username', required: false })
+  @ApiQuery({ name: 'take', required: false })
+  @ApiQuery({ name: 'skip', required: false })
   @ApiResponse(responseExampleForDiary.getDiaries)
   @UseGuards(JwtAuthGuard) // FIXME: 비로그인 상태 로직 생각하기
   getDiaries(
-    @Query('username') username: string,
     @CurrentUser() currentUser: UserDTO,
+    @Query('username') username?: string,
+    @Query('take') take?: number | typeof NaN,
+    @Query('skip') skip?: number | typeof NaN,
   ) {
-    return this.diariesService.getDiaries(currentUser, username);
+    console.log(username, take, skip);
+    return this.diariesService.getDiaries(currentUser, username, take, skip);
   }
 
   @Get('bookmark/:username')

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -73,18 +73,6 @@ export class DiariesService {
     return { selectDiaryInstance, tableAliasInfo };
   }
 
-  async getAll(accessUser: UserDTO) {
-    const { selectDiaryInstance } = this.generateSelectDiaryInstance();
-
-    const diaries = await selectDiaryInstance.getMany();
-
-    const responseDiaries = diaries.map((diary) => {
-      return this.generateCustomFieldForDiary(diary, accessUser.id);
-    });
-
-    return responseDiaries;
-  }
-
   async getDiaries(accessUser: UserDTO, diaryAuthorName?: string) {
     const { selectDiaryInstance, tableAliasInfo } =
       this.generateSelectDiaryInstance();

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -87,6 +87,7 @@ export class DiariesService {
 
     const [diaries, totalCount] = !diaryAuthorName
       ? await selectDiaryInstance
+          .orderBy(`${tableAliasInfo.diary}.createdAt`, 'DESC')
           .take(take ?? defaultTake)
           .skip(skip ?? defaultSkip)
           .getManyAndCount()
@@ -94,6 +95,7 @@ export class DiariesService {
           .where(`${tableAliasInfo.diaryAuthor}.username = :username`, {
             username: diaryAuthorName,
           })
+          .orderBy(`${tableAliasInfo.diary}.createdAt`, 'DESC')
           .take(take ?? defaultTake)
           .skip(skip ?? defaultSkip)
           .getManyAndCount();


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #32 #33

<br />

## 🗒 작업 목록

- [x] 페이지네이션 기능 구현
- [x] 페이지네이션 관련 응답 구조 변경에 따른 swagger 최신화
- [x] swagger에서 일기 리스트 조회 시 skip(페이지 번호), take(한번에 불러올 데이터 개수) 설정할 수 있는 input칸 생성
- [x] 최신 일기 정렬 적용

<br />

## 🧐 PR Point

- 일기 리스트 조회 시 페이지 번호(skip)을 보낼 시 0번이 1페이지, 1번이 2페이지로 구현해두었습니다.
    - 1번이 1페이지, 2번이 2페이지로 하는게 더 편하시다면 말씀해주세요. 반영하여 dev에 합치겠습니다.
- 페이지네이션 적용에 따라 일기 리스트 조회 응답 구조가 변경되었습니다.

**변경 전 응답 구조**
```json
{
  "success": true,
  "data": [
    {
      "id": "uuid",
      "createdAt": "2023-04-10T13:22:32.362Z",
      "updatedAt": "2023-04-10T13:27:16.887Z",
      "title": "string",
      "content": "text",
      "imgUrl": "null | string",
      "favoriteCount": "number",
      "commentCount": "number",
      "isFavorite": "boolean",
      "isBookmark": "boolean",
      "author": {
        "id": "uuid",
        "email": "email string",
        "username": "username string",
        "imgUrl": "url image path",
        "isAdmin": "boolean"
      }
    }
  ]
}
```

**변경 후 응답 구조**
```json
{
  "success": true,
  "data": {
    "diaries": [
      {
        "id": "uuid",
        "createdAt": "2023-04-10T13:22:32.362Z",
        "updatedAt": "2023-04-10T13:27:16.887Z",
        "title": "string",
        "content": "text",
        "imgUrl": "null | string",
        "favoriteCount": "number",
        "commentCount": "number",
        "isFavorite": "boolean",
        "isBookmark": "boolean",
        "author": {
          "id": "uuid",
          "email": "email string",
          "username": "username string",
          "imgUrl": "url image path",
          "isAdmin": "boolean"
        }
      }
    ],
    "totalCount": "number",
    "totalPage": "number"
  }
}
```

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크
- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
