### PR TITLE
comment create api 작업

### DIFF
--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { CommentEntity } from './comments.entity';
 import { CommentsService } from './comments.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CommentEntity])],
+  imports: [TypeOrmModule.forFeature([CommentEntity, DiaryEntity])],
   providers: [CommentsService],
   exports: [CommentsService],
 })

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,4 +1,50 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { commentExceptionMessage } from 'src/constants/exceptionMessage';
+import { DiaryEntity } from 'src/diaries/diaries.entity';
+import { UserDTO } from 'src/users/dto/user.dto';
+import { Repository } from 'typeorm';
+import { CommentEntity } from './comments.entity';
+import { CommentFormDTO } from './dto/comment-form.dto';
 
 @Injectable()
-export class CommentsService {}
+export class CommentsService {
+  constructor(
+    @InjectRepository(CommentEntity)
+    private readonly commentRepository: Repository<CommentEntity>,
+    @InjectRepository(DiaryEntity)
+    private readonly diaryRepository: Repository<DiaryEntity>,
+  ) {}
+
+  async createComment(
+    diaryId: string,
+    accessedUser: UserDTO,
+    commentFormDTO: CommentFormDTO,
+  ) {
+    const targetDiary = await this.diaryRepository.findOneBy({ id: diaryId });
+
+    const targetDiary1 = await this.diaryRepository
+      .createQueryBuilder('diary')
+      .leftJoinAndSelect('diary.comments', 'comments')
+      .where({ id: diaryId })
+      .getOne();
+
+    if (!targetDiary) {
+      return new NotFoundException(commentExceptionMessage.DOES_NOT_DIARY);
+    }
+
+    console.log(targetDiary1);
+
+    targetDiary.commentCount += 1;
+    const newComment = await this.commentRepository.create({
+      commenter: accessedUser,
+      diary: targetDiary,
+      comment: commentFormDTO.comment,
+    });
+
+    await this.diaryRepository.save(targetDiary);
+    await this.commentRepository.save(newComment);
+
+    return newComment;
+  }
+}

--- a/src/comments/dto/comment-form.dto.ts
+++ b/src/comments/dto/comment-form.dto.ts
@@ -1,0 +1,6 @@
+import { PickType } from '@nestjs/swagger';
+import { CommentEntity } from '../comments.entity';
+
+export class CommentFormDTO extends PickType(CommentEntity, [
+  'comment',
+] as const) {}

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -23,3 +23,7 @@ export const bookmarkExceptionMessage = {
   DOES_NOT_REGISTER_BOOKMARK:
     '접근한 계정으로 해당 게시물에 북마크가 등록 되어있지 않아 북마크 취소가 불가능합니다.',
 };
+
+export const commentExceptionMessage = {
+  DOES_NOT_DIARY: '해당하는 게시물은 존재하지 않습니다.',
+};

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -124,3 +124,14 @@ export const responseExampleForBookmark = {
     message: '북마크 등록이 취소되었습니다.',
   }),
 };
+
+export const responseExampleForComment = {
+  createComment: responseTemplate({
+    id: 'uuid',
+    createdAt: '2023-04-22T10:24:58.188Z',
+    updatedAt: '2023-04-22T10:24:58.188Z',
+    comment: 'text',
+    commenter: userResponse,
+    diary: diaryResponse,
+  }),
+};

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -24,6 +24,8 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { BookmarksService } from 'src/bookmarks/bookmarks.service';
+import { CommentsService } from 'src/comments/comments.service';
+import { CommentFormDTO } from 'src/comments/dto/comment-form.dto';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { FileUploadDto } from 'src/common/dto/FileUpload.dto';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
@@ -46,6 +48,7 @@ export class DiariesController {
     private readonly diariesService: DiariesService,
     private readonly favoritesService: FavoritesService,
     private readonly bookmarksService: BookmarksService,
+    private readonly commentsService: CommentsService,
   ) {}
 
   @Post('upload')
@@ -206,5 +209,20 @@ export class DiariesController {
     @CurrentUser() currentUser: UserDTO,
   ) {
     return this.bookmarksService.unregister(id, currentUser);
+  }
+
+  // 댓글 API
+  @Post(':diaryId/comment')
+  @UseGuards(JwtAuthGuard)
+  createComment(
+    @Param('diaryId', ParseUUIDPipe) diaryId: string,
+    @CurrentUser() currentUser: UserDTO,
+    @Body() commentFormDTO: CommentFormDTO,
+  ) {
+    return this.commentsService.createComment(
+      diaryId,
+      currentUser,
+      commentFormDTO,
+    );
   }
 }

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -31,6 +31,7 @@ import { FileUploadDto } from 'src/common/dto/FileUpload.dto';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
 import {
   responseExampleForBookmark,
+  responseExampleForComment,
   responseExampleForDiary,
   responseExampleForFavorite,
 } from 'src/constants/swagger';
@@ -213,6 +214,11 @@ export class DiariesController {
 
   // 댓글 API
   @Post(':diaryId/comment')
+  @ApiOperation({
+    summary: '댓글 생성',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiResponse(responseExampleForComment.createComment)
   @UseGuards(JwtAuthGuard)
   createComment(
     @Param('diaryId', ParseUUIDPipe) diaryId: string,

--- a/src/diaries/diaries.module.ts
+++ b/src/diaries/diaries.module.ts
@@ -6,12 +6,14 @@ import { FavoritesModule } from 'src/favorities/favorites.module';
 import { DiariesController } from './diaries.controller';
 import { DiaryEntity } from './diaries.entity';
 import { DiariesService } from './diaries.service';
+import { CommentsModule } from 'src/comments/comments.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([DiaryEntity]),
     FavoritesModule,
     BookmarksModule,
+    CommentsModule,
   ],
   controllers: [DiariesController],
   providers: [DiariesService, AwsService],


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #43

## 상위 이슈

- #40 

<br />

## 🗒 작업 목록

- [x]  create api 개발
- [x]  각 API swagger 적용
- [x]  notion API 설계 문서 최신화

<br />

## 🧐 PR Point

- 일기 생성 시 일기 컴포넌트의 commentCount state 갱신을 위해 diary의 정보와 댓글 리스트 컴포넌트의 comment list state에 새로 추가될 comment의 정보를 담을 수 있도록 comment 데이터와 user 정보까지 같이 반환하도록 구현하였습니다.
- 아래는 일기 생성 시 response의 구조입니다.

```json
{
  "success": true,
  "data": {
    "id": "uuid",
    "createdAt": "2023-04-22T10:24:58.188Z",
    "updatedAt": "2023-04-22T10:24:58.188Z",
    "comment": "text",
    "commenter": {
      "id": "uuid",
      "email": "email string",
      "username": "username string",
      "imgUrl": "url image path",
      "isAdmin": "boolean"
    },
    "diary": {
      "id": "uuid",
      "createdAt": "2023-04-10T13:22:32.362Z",
      "updatedAt": "2023-04-10T13:27:16.887Z",
      "title": "string",
      "content": "text",
      "imgUrl": "null | string",
      "favoriteCount": "number",
      "commentCount": "number"
    }
  }
}
```

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
