### PR TITLE
댓글 조회 API 작업 완료

### DIFF
--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -23,17 +23,9 @@ export class CommentsService {
   ) {
     const targetDiary = await this.diaryRepository.findOneBy({ id: diaryId });
 
-    const targetDiary1 = await this.diaryRepository
-      .createQueryBuilder('diary')
-      .leftJoinAndSelect('diary.comments', 'comments')
-      .where({ id: diaryId })
-      .getOne();
-
     if (!targetDiary) {
       return new NotFoundException(commentExceptionMessage.DOES_NOT_DIARY);
     }
-
-    console.log(targetDiary1);
 
     targetDiary.commentCount += 1;
     const newComment = await this.commentRepository.create({

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -39,4 +39,25 @@ export class CommentsService {
 
     return newComment;
   }
+
+  async getCommentList(diaryId: string, take?: number, skip?: number) {
+    const commentsPageTake = take ?? 5;
+    const commentsPageSkip = skip ?? 0;
+
+    const [commentsByDiary, totalCount] = await this.commentRepository
+      .createQueryBuilder('comment')
+      .leftJoinAndSelect('comment.commenter', 'commenter')
+      .leftJoin('comment.diary', 'diary')
+      .where('diary.id = :id', { id: diaryId })
+      .orderBy('comment.createdAt', 'DESC')
+      .take(commentsPageTake)
+      .skip(commentsPageSkip)
+      .getManyAndCount();
+
+    return {
+      comments: commentsByDiary,
+      totalCount,
+      totalPage: Math.ceil(totalCount / commentsPageTake),
+    };
+  }
 }

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -134,4 +134,17 @@ export const responseExampleForComment = {
     commenter: userResponse,
     diary: diaryResponse,
   }),
+  getCommentList: responseTemplate({
+    comments: [
+      {
+        id: 'uuid',
+        createdAt: '2023-04-23T03:29:33.979Z',
+        updatedAt: '2023-04-23T03:29:33.979Z',
+        comment: 'text',
+        commenter: userResponse,
+      },
+    ],
+    totalCount: 'number',
+    totalPage: 'number',
+  }),
 };

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -231,4 +231,14 @@ export class DiariesController {
       commentFormDTO,
     );
   }
+
+  @Get(':diaryId/comment')
+  @UseGuards(JwtAuthGuard)
+  getCommentList(
+    @Param('diaryId', ParseUUIDPipe) diaryId: string,
+    @Query('take') take?: number | typeof NaN,
+    @Query('skip') skip?: number | typeof NaN,
+  ) {
+    return this.commentsService.getCommentList(diaryId, take, skip);
+  }
 }

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -233,6 +233,13 @@ export class DiariesController {
   }
 
   @Get(':diaryId/comment')
+  @ApiOperation({
+    summary: '댓글 리스트 조회',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiQuery({ name: 'take', required: false, description: 'default value: 5' })
+  @ApiQuery({ name: 'skip', required: false, description: 'default value: 0' })
+  @ApiResponse(responseExampleForComment.getCommentList)
   @UseGuards(JwtAuthGuard)
   getCommentList(
     @Param('diaryId', ParseUUIDPipe) diaryId: string,


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #44

## 상위 이슈 
- #40

<br />

## 🗒 작업 목록

- [x] 리스트 조회 api 개발
    - [x] 페이지네이션 구현
    - [x] 최신 댓글이 먼저 조회되게 구현
- [x] 각 API swagger 적용
- [x] notion API 설계 문서 최신화

<br />

## 🧐 PR Point

- comment 조회 response 구조입니다.
- 일기 리스트 조회에서의 구조와 비슷하게 구조 잡았습니다.
```json
{
  "success": true,
  "data": {
    "comments": [
      {
        "id": "uuid",
        "createdAt": "2023-04-23T03:29:33.979Z",
        "updatedAt": "2023-04-23T03:29:33.979Z",
        "comment": "text",
        "commenter": {
          "id": "uuid",
          "email": "email string",
          "username": "username string",
          "imgUrl": "url image path",
          "isAdmin": "boolean"
        }
      },
    ],
    "totalCount": "number",
    "totalPage": "number"
  }
}
```

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크
 
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/77317312/233818957-5632b0d8-f497-4aca-a5ea-7e5aedd81cae.png">


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
