### PR TITLE
Feature/45/comment delete

### DIFF
--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,6 +1,13 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { commentExceptionMessage } from 'src/constants/exceptionMessage';
+import {
+  commentExceptionMessage,
+  diaryExceptionMessage,
+} from 'src/constants/exceptionMessage';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { Repository } from 'typeorm';
@@ -24,7 +31,7 @@ export class CommentsService {
     const targetDiary = await this.diaryRepository.findOneBy({ id: diaryId });
 
     if (!targetDiary) {
-      return new NotFoundException(commentExceptionMessage.DOES_NOT_DIARY);
+      throw new NotFoundException(diaryExceptionMessage.DOES_NOT_EXIST_DIARY);
     }
 
     targetDiary.commentCount += 1;
@@ -59,5 +66,46 @@ export class CommentsService {
       totalCount,
       totalPage: Math.ceil(totalCount / commentsPageTake),
     };
+  }
+
+  async deleteComment(
+    diaryId: string,
+    commentId: string,
+    accessedUser: UserDTO,
+  ) {
+    const targetDiary = await this.diaryRepository
+      .createQueryBuilder('diary')
+      .leftJoinAndSelect('diary.author', 'author')
+      .where('diary.id = :id', { id: diaryId })
+      .getOne();
+
+    if (!targetDiary) {
+      throw new NotFoundException(diaryExceptionMessage.DOES_NOT_EXIST_DIARY);
+    }
+
+    const targetComment = await this.commentRepository
+      .createQueryBuilder('comment')
+      .leftJoinAndSelect('comment.commenter', 'commenter')
+      .where('comment.id = :id', { id: commentId })
+      .getOne();
+
+    if (!targetComment) {
+      throw new NotFoundException(
+        commentExceptionMessage.DOES_NOT_EXIST_COMMENT,
+      );
+    }
+
+    const diaryAuthorId = targetDiary.author.id;
+    const commenterId = targetComment.commenter.id;
+
+    if (![diaryAuthorId, commenterId].includes(accessedUser.id)) {
+      throw new BadRequestException(commentExceptionMessage.OWNER_ONLY_DELETE);
+    }
+
+    targetDiary.commentCount -= 1;
+    await this.diaryRepository.save(targetDiary);
+    await this.commentRepository.softDelete(commentId);
+
+    return { message: '삭제되었습니다.' };
   }
 }

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -25,5 +25,7 @@ export const bookmarkExceptionMessage = {
 };
 
 export const commentExceptionMessage = {
-  DOES_NOT_DIARY: '해당하는 게시물은 존재하지 않습니다.',
+  DOES_NOT_EXIST_COMMENT: '해당하는 댓글은 존재하지 않습니다.',
+  OWNER_ONLY_DELETE:
+    '일기 작성자 혹은 댓글 작성자만이 해당 댓글을 삭제할 수 있습니다.',
 };

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -151,4 +151,7 @@ export const responseExampleForComment = {
     totalCount: 'number',
     totalPage: 'number',
   }),
+  deleteComment: responseTemplate({
+    message: '삭제되었습니다.',
+  }),
 };

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -254,6 +254,11 @@ export class DiariesController {
   }
 
   @Delete(':diaryId/comment/:commentId')
+  @ApiOperation({
+    summary: '댓글 삭제',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiResponse(responseExampleForComment.deleteComment)
   @UseGuards(JwtAuthGuard)
   deleteComment(
     @Param('diaryId', ParseUUIDPipe) diaryId: string,

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -252,4 +252,14 @@ export class DiariesController {
   ) {
     return this.commentsService.getCommentList(diaryId, take, skip);
   }
+
+  @Delete(':diaryId/comment/:commentId')
+  @UseGuards(JwtAuthGuard)
+  deleteComment(
+    @Param('diaryId', ParseUUIDPipe) diaryId: string,
+    @Param('commentId', ParseUUIDPipe) commentId: string,
+    @CurrentUser() currentUser: UserDTO,
+  ) {
+    return this.commentsService.deleteComment(diaryId, commentId, currentUser);
+  }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #45

## 상위 이슈
- #40 

<br />

## 🗒 작업 목록

- [x] delete api 개발
    - [x] 일기가 없는 경우 예외처리 -> Not Found
    - [x] 댓글이 없는 경우 예외처리 -> Not Found
    - [x] 일기 작성자 혹은 댓글 작성자가 아닌 경우 댓글 삭제 시 예외처리 -> Bad Request
    - [x] 삭제에 성공된 경우 diary의 Comment field 감소 로직 추가
- [x] API swagger 적용
- [x] notion API 설계 문서 최신화

<br />

## 🧐 PR Point

- 어떤 이유로 코드를 변경했나요?
- 리뷰어가 집중해야하는 포인트가 어디인가요?
- 해당 작업에서 주의 해야할 부분이 있나요?

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/77317312/233824248-b5276f58-ac4e-45ef-9e97-d1b80a8acbe3.png">


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
