### PR TITLE
약관 동의 이력 API 개발

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { AwsService } from './aws.service';
 import { CommentsModule } from './comments/comments.module';
 import { BadgesModule } from './badges/badges.module';
 import { TermsAgreementsModule } from './terms-agreements/terms-agreements.module';
+import { UserToTermsAgreementsModule } from './user-to-terms-agreements/user-to-terms-agreements.module';
 
 const typeOrmModuleOptions = {
   useFactory: async (): Promise<TypeOrmModuleOptions> => {
@@ -46,6 +47,7 @@ const typeOrmModuleOptions = {
     CommentsModule,
     BadgesModule,
     TermsAgreementsModule,
+    UserToTermsAgreementsModule,
   ],
   controllers: [AppController],
   providers: [AppService, AwsService],

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -39,4 +39,5 @@ export const badgeExceptionMessage = {
 
 export const termsAgreementExceptionMessage = {
   DOES_NOT_EXIST_TERMS_AGREEMENT: '해당하는 약관동의는 존재하지 않습니다.',
+  INVALIDATE_TERMS_AGREEMENTS: '필수 약관동의를 체크해주세요',
 };

--- a/src/diaries/diaries.entity.ts
+++ b/src/diaries/diaries.entity.ts
@@ -44,7 +44,6 @@ export class DiaryEntity extends CommonEntity {
   @Column({ type: 'int', default: 0 })
   commentCount: number;
 
-  // TODO: bookmark, comment table relationship 필요
   @ApiProperty()
   @ManyToOne(() => UserEntity, (author: UserEntity) => author.diaries, {
     onDelete: 'CASCADE',

--- a/src/terms-agreements/terms-agreements.entity.ts
+++ b/src/terms-agreements/terms-agreements.entity.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsString, IsUUID } from 'class-validator';
-import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { UserToTermsAgreementEntity } from 'src/user-to-terms-agreements/user-to-terms-agreements.entity';
+import { UserToBadgeEntity } from 'src/users/userToBadge.entity';
+import {
+  Column,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 @Index('termsAgreementId', ['id'], { unique: true })
 @Entity({
@@ -27,4 +35,14 @@ export class TermsAgreementEntity {
   @IsBoolean()
   @Column({ nullable: false })
   isRequired: boolean;
+
+  @ApiProperty()
+  @OneToMany(
+    () => UserToTermsAgreementEntity,
+    (userToTermsAgreement) => userToTermsAgreement.termsAgreement,
+    {
+      cascade: true,
+    },
+  )
+  userToTermsAgreements: UserToBadgeEntity[];
 }

--- a/src/terms-agreements/terms-agreements.module.ts
+++ b/src/terms-agreements/terms-agreements.module.ts
@@ -8,5 +8,6 @@ import { TermsAgreementEntity } from './terms-agreements.entity';
   imports: [TypeOrmModule.forFeature([TermsAgreementEntity])],
   providers: [TermsAgreementsService],
   controllers: [TermsAgreementsController],
+  exports: [TermsAgreementsService],
 })
 export class TermsAgreementsModule {}

--- a/src/terms-agreements/terms-agreements.service.ts
+++ b/src/terms-agreements/terms-agreements.service.ts
@@ -16,6 +16,29 @@ export class TermsAgreementsService {
     return await this.termsAgreementRepository.findOneBy({ id });
   }
 
+  async getRequiredTermsAgreements() {
+    return await this.termsAgreementRepository.find({
+      where: { isRequired: true },
+    });
+  }
+
+  /**
+   * 파라미터로 전달받은 값이 필수 약관동의에 적합한지 확인해주는 함수
+   *
+   * validate한 경우 true 반환
+   * 그렇지 않은 경우 false 반환
+   */
+  async validatorRequiredTermsAgreements(checkTermsAgreementIdList: string[]) {
+    const requiredTermsAgreements = await this.getRequiredTermsAgreements();
+    const requiredTermsAgreementIdList = requiredTermsAgreements.map(
+      (el) => el.id,
+    );
+
+    return requiredTermsAgreementIdList.every((requiredId) =>
+      checkTermsAgreementIdList.includes(requiredId),
+    );
+  }
+
   async createTermsAgreement(termsAgreementFormDTO: TermsAgreementFormDTO) {
     const newTermsAgreement = this.termsAgreementRepository.create(
       termsAgreementFormDTO,

--- a/src/user-to-terms-agreements/user-to-terms-agreements.entity.ts
+++ b/src/user-to-terms-agreements/user-to-terms-agreements.entity.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsUUID } from 'class-validator';
+import { TermsAgreementEntity } from 'src/terms-agreements/terms-agreements.entity';
+import { UserEntity } from 'src/users/users.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Index('userToTermsAgreementId', ['id'], { unique: true })
+@Entity({
+  name: 'USER_TO_TERMS_AGREEMENT',
+})
+export class UserToTermsAgreementEntity {
+  @IsUUID()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty()
+  @ManyToOne(
+    () => UserEntity,
+    (user: UserEntity) => user.userToTermsAgreements,
+    {
+      onDelete: 'CASCADE',
+    },
+  )
+  @JoinColumn({
+    name: 'user_id',
+    referencedColumnName: 'id',
+  })
+  user: UserEntity;
+
+  @ApiProperty()
+  @ManyToOne(
+    () => TermsAgreementEntity,
+    (termsAgreement: TermsAgreementEntity) =>
+      termsAgreement.userToTermsAgreements,
+    {
+      onDelete: 'CASCADE',
+    },
+  )
+  @JoinColumn({
+    name: 'termsAgreement_id',
+    referencedColumnName: 'id',
+  })
+  termsAgreement: TermsAgreementEntity;
+
+  @ApiProperty()
+  @IsBoolean()
+  @Column({ nullable: false })
+  isAgreed: boolean;
+
+  @CreateDateColumn({
+    type: 'timestamptz' /* timestamp with time zone */,
+  })
+  createdAt: Date;
+}

--- a/src/user-to-terms-agreements/user-to-terms-agreements.module.ts
+++ b/src/user-to-terms-agreements/user-to-terms-agreements.module.ts
@@ -1,7 +1,15 @@
 import { Module } from '@nestjs/common';
 import { UserToTermsAgreementsService } from './user-to-terms-agreements.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserToTermsAgreementEntity } from './user-to-terms-agreements.entity';
+import { TermsAgreementsModule } from 'src/terms-agreements/terms-agreements.module';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([UserToTermsAgreementEntity]),
+    TermsAgreementsModule,
+  ],
   providers: [UserToTermsAgreementsService],
+  exports: [UserToTermsAgreementsService],
 })
 export class UserToTermsAgreementsModule {}

--- a/src/user-to-terms-agreements/user-to-terms-agreements.module.ts
+++ b/src/user-to-terms-agreements/user-to-terms-agreements.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { UserToTermsAgreementsService } from './user-to-terms-agreements.service';
+
+@Module({
+  providers: [UserToTermsAgreementsService],
+})
+export class UserToTermsAgreementsModule {}

--- a/src/user-to-terms-agreements/user-to-terms-agreements.service.ts
+++ b/src/user-to-terms-agreements/user-to-terms-agreements.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UserToTermsAgreementsService {}

--- a/src/user-to-terms-agreements/user-to-terms-agreements.service.ts
+++ b/src/user-to-terms-agreements/user-to-terms-agreements.service.ts
@@ -1,4 +1,48 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserToTermsAgreementEntity } from './user-to-terms-agreements.entity';
+import { Repository } from 'typeorm';
+import { UserDTO } from 'src/users/dto/user.dto';
+import { TermsAgreementsService } from 'src/terms-agreements/terms-agreements.service';
+import { termsAgreementExceptionMessage } from 'src/constants/exceptionMessage';
 
 @Injectable()
-export class UserToTermsAgreementsService {}
+export class UserToTermsAgreementsService {
+  constructor(
+    @InjectRepository(UserToTermsAgreementEntity)
+    private readonly userToTermsAgreementRepository: Repository<UserToTermsAgreementEntity>,
+    private readonly termsAgreementsService: TermsAgreementsService,
+  ) {}
+
+  async saveUserToTermsAgreement(
+    user: UserDTO,
+    userCheckedTermsAgreementIdList: string[],
+  ) {
+    const isValidateTermsAgreement =
+      await this.termsAgreementsService.validatorRequiredTermsAgreements(
+        userCheckedTermsAgreementIdList,
+      );
+
+    // 필수 값이 체크되지 않은 경우 early return
+    if (!isValidateTermsAgreement)
+      throw new BadRequestException(
+        termsAgreementExceptionMessage.INVALIDATE_TERMS_AGREEMENTS,
+      );
+
+    const termsAgreementList =
+      await this.termsAgreementsService.getTermsAgreementList();
+
+    termsAgreementList.forEach(async (termsAgreement) => {
+      const newUserToTermsAgreement =
+        this.userToTermsAgreementRepository.create({
+          user,
+          termsAgreement,
+          isAgreed: userCheckedTermsAgreementIdList.includes(termsAgreement.id),
+        });
+
+      await this.userToTermsAgreementRepository.save(newUserToTermsAgreement);
+    });
+
+    return true;
+  }
+}

--- a/src/users/dto/user-join.dto.ts
+++ b/src/users/dto/user-join.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { UserEntity } from '../users.entity';
-import { IsString, IsNotEmpty, IsBoolean } from 'class-validator';
+import { IsString, IsNotEmpty, IsArray } from 'class-validator';
 import { Column } from 'typeorm';
 
 export class UserJoinDTO extends PickType(UserEntity, [
@@ -14,9 +14,9 @@ export class UserJoinDTO extends PickType(UserEntity, [
   password: string;
 
   @ApiProperty()
-  @IsBoolean()
-  @Column({ type: 'boolean', nullable: false })
-  isAgree: boolean;
+  @IsArray()
+  @Column({ type: 'array', nullable: false })
+  termsAgreementIdList: string[];
 }
 
 export class UserEmailDTO extends PickType(UserEntity, ['email'] as const) {}

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -59,12 +59,6 @@ export class UserEntity {
 
   @ApiProperty()
   @IsBoolean()
-  @Exclude()
-  @Column({ type: 'boolean', nullable: false })
-  isAgree: boolean;
-
-  @ApiProperty()
-  @IsBoolean()
   @Column({ type: 'boolean', default: false })
   isAdmin: boolean;
 

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -23,6 +23,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { UserToBadgeEntity } from './userToBadge.entity';
+import { UserToTermsAgreementEntity } from 'src/user-to-terms-agreements/user-to-terms-agreements.entity';
 
 @Index('email', ['email'], { unique: true })
 @Entity({
@@ -122,4 +123,14 @@ export class UserEntity {
   @ApiProperty()
   @OneToMany(() => UserToBadgeEntity, (userToBadge) => userToBadge.user)
   userToBadges: UserToBadgeEntity[];
+
+  @ApiProperty()
+  @OneToMany(
+    () => UserToTermsAgreementEntity,
+    (userToTermsAgreement) => userToTermsAgreement.user,
+    {
+      cascade: true,
+    },
+  )
+  userToTermsAgreements: UserToBadgeEntity[];
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -11,6 +11,7 @@ import { BookmarkEntity } from 'src/bookmarks/bookmarks.entity';
 import { AwsService } from 'src/aws.service';
 import { UserToBadgeEntity } from './userToBadge.entity';
 import { UserToTermsAgreementEntity } from 'src/user-to-terms-agreements/user-to-terms-agreements.entity';
+import { UserToTermsAgreementsModule } from 'src/user-to-terms-agreements/user-to-terms-agreements.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { UserToTermsAgreementEntity } from 'src/user-to-terms-agreements/user-to
       secretOrPrivateKey: process.env.SECRET_KEY,
       signOptions: { expiresIn: '1d' },
     }),
+    UserToTermsAgreementsModule,
   ],
   controllers: [UsersController],
   providers: [UsersService, JwtStrategy, AwsService],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -10,6 +10,7 @@ import { FavoriteEntity } from 'src/favorities/favorites.entity';
 import { BookmarkEntity } from 'src/bookmarks/bookmarks.entity';
 import { AwsService } from 'src/aws.service';
 import { UserToBadgeEntity } from './userToBadge.entity';
+import { UserToTermsAgreementEntity } from 'src/user-to-terms-agreements/user-to-terms-agreements.entity';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { UserToBadgeEntity } from './userToBadge.entity';
       FavoriteEntity,
       BookmarkEntity,
       UserToBadgeEntity,
+      UserToTermsAgreementEntity,
     ]),
     PassportModule.register({ defaultStrategy: 'jwt', session: false }),
     JwtModule.register({


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #70 

<br />
 
## 🗒 작업 목록

- [x] 약관 동의 이력 테이블 생성
    - [x] 약관 테이블과 OneToMany 연결 - cascade
    - [x] 유저 테이블과 OneToMany 연결 - cascade
- [x] 약관 동의 생성 서비스 개발
    - [x] 사용자 회원가입 로직에 생성한 약관 동의 서비스 사용


<br />

## 🧐 PR Point

- 기존에 설계하였던 것을 프론트엔드에서 약관동의 여부를 boolean으로 요청보내는 식으로 설계를 하였다.
- 하지만 이용 약관에 변경이 발생한 경우 개발의 추가적인 작업이 필요할 것으로 예상 됨.

- 해당 문제를 해결하기 위해 요청 값으로 보내주었던 boolean 대신 이용약관의 ID를 요청으로 보내는 식으로 구현하였습니다.
- 백엔드 디비에 이용 약관 API를 개발(terms-agreements)
- 프론트에서는 이용 약관 API를 통해 저장되어 있는 약관을 화면에 보여줍니다.
- 사용자가 선택한 이용 약관의 아이디 리스트를 백엔드에 요청
- 이용 약관의 확장성을 고려하여 위와 같이 구현하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크
![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/06e6f617-17a7-4d82-84e8-7f6055a68eb3)


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
