### PR TITLE
일부 api endpoint 변경

### DIFF
--- a/src/badges/badges.controller.ts
+++ b/src/badges/badges.controller.ts
@@ -41,7 +41,7 @@ import { BadgeFormDTO } from './dto/badge-form.dto';
 export class BadgesController {
   constructor(private readonly badgesService: BadgesService) {}
 
-  @Post('upload')
+  @Post('upload-image')
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     description: 'formdata instance에 append 시 key값을 image로 설정해주세요.',

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -55,13 +55,13 @@ export const responseExampleForCommon = {
 };
 
 export const responseExampleForUser = {
-  emailCheck: responseTemplate({
+  emailExists: responseTemplate({
     message: '사용가능한 이메일입니다.',
   }),
-  usernameCheck: responseTemplate({
+  usernameExists: responseTemplate({
     message: '사용가능한 유저이름입니다.',
   }),
-  join: responseTemplate({
+  register: responseTemplate({
     message: '회원가입에 성공하였습니다.',
   }),
   login: responseTemplate({

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -53,7 +53,7 @@ export class DiariesController {
     private readonly commentsService: CommentsService,
   ) {}
 
-  @Post('upload')
+  @Post('upload-image')
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     description: 'formdata instance에 append 시 key값을 image로 설정해주세요.',

--- a/src/terms-agreements/terms-agreements.controller.ts
+++ b/src/terms-agreements/terms-agreements.controller.ts
@@ -24,7 +24,7 @@ export class TermsAgreementsController {
 
   @Post()
   @ApiOperation({
-    summary: '약관 생성',
+    summary: '약관 생성 (관리자)',
   })
   @ApiResponse(responseExampleForTermsAgreement.createTermsAgreement)
   createTermsAgreement(@Body() termsAgreementFormDTO: TermsAgreementFormDTO) {
@@ -55,7 +55,7 @@ export class TermsAgreementsController {
 
   @Delete(':termsAgreementId')
   @ApiOperation({
-    summary: '약관 삭제',
+    summary: '약관 삭제 (관리자)',
   })
   @ApiResponse(responseExampleForTermsAgreement.deleteTermsAgreement)
   deleteTermsAgreement(

--- a/src/users/dto/user-register.dto.ts
+++ b/src/users/dto/user-register.dto.ts
@@ -3,7 +3,7 @@ import { UserEntity } from '../users.entity';
 import { IsString, IsNotEmpty, IsArray } from 'class-validator';
 import { Column } from 'typeorm';
 
-export class UserJoinDTO extends PickType(UserEntity, [
+export class UserRegisterDTO extends PickType(UserEntity, [
   'email',
   'username',
   'imgUrl',

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -6,29 +6,28 @@ import {
   Post,
   UploadedFile,
   UseFilters,
-  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
-  ApiBearerAuth,
   ApiBody,
   ApiConsumes,
   ApiResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { FileUploadDto } from 'src/common/dto/FileUpload.dto';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
 import {
   responseExampleForCommon,
   responseExampleForUser,
 } from 'src/constants/swagger';
-import { UserEmailDTO, UserJoinDTO, UsernameDTO } from './dto/user-join.dto';
+import {
+  UserEmailDTO,
+  UserRegisterDTO,
+  UsernameDTO,
+} from './dto/user-register.dto';
 import { UserLoginDTO } from './dto/user-login.dto';
-import { UserDTO } from './dto/user.dto';
-import { JwtAuthGuard } from './jwt/jwt.guard';
 import { UsersService } from './users.service';
 
 @ApiTags('USER')
@@ -37,7 +36,7 @@ import { UsersService } from './users.service';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Post('upload')
+  @Post('upload-image')
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     description: 'formdata instance에 append 시 key값을 image로 설정해주세요.',
@@ -53,20 +52,9 @@ export class UsersController {
     return this.usersService.uploadImg(file);
   }
 
-  @Get()
+  @Get('')
   @ApiOperation({
-    summary: '내 정보 조회 (토큰 필요)',
-  })
-  @ApiBearerAuth('access-token')
-  @ApiResponse(responseExampleForUser.getCurrentUser)
-  @UseGuards(JwtAuthGuard)
-  getCurrentUser(@CurrentUser() currentUser: UserDTO) {
-    return currentUser;
-  }
-
-  @Get('all')
-  @ApiOperation({
-    summary: '전체 유저 조회',
+    summary: '전체 유저 조회 (개발용)',
   })
   @ApiResponse(responseExampleForUser.getAllUsers)
   getAllUser() {
@@ -91,31 +79,31 @@ export class UsersController {
     return this.usersService.findUserByUsername(username);
   }
 
-  @Post()
-  @ApiOperation({
-    summary: '회원가입',
-  })
-  @ApiResponse(responseExampleForUser.join)
-  join(@Body() userJoinDto: UserJoinDTO) {
-    return this.usersService.join(userJoinDto);
-  }
-
-  @Post('email-check')
+  @Post('email-exists')
   @ApiOperation({
     summary: '이메일 중복 체크',
   })
-  @ApiResponse(responseExampleForUser.emailCheck)
-  emailCheck(@Body() userEmail: UserEmailDTO) {
-    return this.usersService.emailCheck(userEmail);
+  @ApiResponse(responseExampleForUser.emailExists)
+  emailExists(@Body() userEmail: UserEmailDTO) {
+    return this.usersService.emailExists(userEmail);
   }
 
-  @Post('username-check')
+  @Post('username-exists')
   @ApiOperation({
     summary: '유저 이름 중복 체크',
   })
-  @ApiResponse(responseExampleForUser.usernameCheck)
-  usernameCheck(@Body() { username }: UsernameDTO) {
-    return this.usersService.usernameCheck(username);
+  @ApiResponse(responseExampleForUser.usernameExists)
+  usernameExists(@Body() { username }: UsernameDTO) {
+    return this.usersService.usernameExists(username);
+  }
+
+  @Post('register')
+  @ApiOperation({
+    summary: '회원가입',
+  })
+  @ApiResponse(responseExampleForUser.register)
+  register(@Body() UserRegisterDTO: UserRegisterDTO) {
+    return this.usersService.register(UserRegisterDTO);
   }
 
   @Post('login')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -8,7 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 
-import { UserEmailDTO, UserJoinDTO } from './dto/user-join.dto';
+import { UserEmailDTO, UserRegisterDTO } from './dto/user-register.dto';
 import { UserEntity } from './users.entity';
 import { UserLoginDTO } from './dto/user-login.dto';
 import { JwtService } from '@nestjs/jwt';
@@ -30,9 +30,9 @@ export class UsersService {
     return { imgUrl: this.awsService.getAwsS3FileUrl(uploadInfo.key) };
   }
 
-  async join(userJoinDTO: UserJoinDTO) {
+  async register(userRegisterDTO: UserRegisterDTO) {
     const { email, username, password, imgUrl, termsAgreementIdList } =
-      userJoinDTO;
+      userRegisterDTO;
 
     const userByEmail = await this.usersRepository.findOneBy({ email });
     if (userByEmail) {
@@ -63,7 +63,7 @@ export class UsersService {
     return { message: '회원가입에 성공하였습니다.' };
   }
 
-  async emailCheck(userEmail: UserEmailDTO) {
+  async emailExists(userEmail: UserEmailDTO) {
     const { email } = userEmail;
 
     const user = await this.usersRepository.findOneBy({ email });
@@ -74,7 +74,7 @@ export class UsersService {
     return { message: '사용가능한 이메일입니다.' };
   }
 
-  async usernameCheck(username: string) {
+  async usernameExists(username: string) {
     const user = await this.usersRepository.findOneBy({
       username,
     });
@@ -86,8 +86,8 @@ export class UsersService {
     return { message: '사용가능한 유저이름입니다.' };
   }
 
-  async login(userloginDto: UserLoginDTO) {
-    const { email, password } = userloginDto;
+  async login(userLoginDto: UserLoginDTO) {
+    const { email, password } = userLoginDto;
     const user = await this.usersRepository.findOneBy({ email });
 
     if (!user || !(await bcrypt.compare(password, user.password))) {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #72 

<br />

## 🗒 작업 목록
- [x] 회원가입 : `/users/register`
- [x] 사용자 정보 조회 : `/users/{username}`
- [ ] 사용자 정보 수정/삭제 : `/users/{userId}`
- [x] 사용자 전체 정보 조회 : `/users`
- [x] 사용자 이미지 업로드 : `/users/upload-image`
- [x] 다이어리 이미지 업로드 : `/diaries/upload-image`
- [x] 뱃지 이미지 업로드 : `/badges/upload-image`
- [x] 이메일 중복 체크 : `/users/email-exists`
- [x] 닉네임 중복 체크 : `/users/username-exists`
- [x] 변경 사항 API 설계 문서 적용
- [x] 개발용 API는 swagger description 뒤에 (개발용) 이라는 suffix 추가


<br />

## 🧐 PR Point

- 사용자 정보 수정, 삭제의 경우 사용자들에게 흔히 노출되는 username보다는 id로 접근하는 것이 조금 더 안전하다고 생각하며, token이 validate한 유저만 수정과 삭제 API를 사용할 수 있도록 구현할 예정입니다.
<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
