### PR TITLE
약관동의 페이지 id 변경

### DIFF
--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -39,7 +39,7 @@ const badgeResponse = {
 };
 
 const termsAgreementResponse = {
-  id: 'number',
+  id: 'service | privacy | marketing',
   title: 'string',
   content: 'string',
   isRequired: 'boolean',

--- a/src/terms-agreements/dto/terms-agreement-form.dto.ts
+++ b/src/terms-agreements/dto/terms-agreement-form.dto.ts
@@ -2,6 +2,7 @@ import { PickType } from '@nestjs/swagger';
 import { TermsAgreementEntity } from '../terms-agreements.entity';
 
 export class TermsAgreementFormDTO extends PickType(TermsAgreementEntity, [
+  'id',
   'title',
   'content',
   'isRequired',

--- a/src/terms-agreements/terms-agreements.controller.ts
+++ b/src/terms-agreements/terms-agreements.controller.ts
@@ -4,15 +4,15 @@ import {
   Delete,
   Get,
   Param,
-  ParseUUIDPipe,
   Post,
   UseFilters,
 } from '@nestjs/common';
 import { TermsAgreementsService } from './terms-agreements.service';
-import { TermsAgreementFormDTO } from './dto/terms-agreemtn-form.dto';
+import { TermsAgreementFormDTO } from './dto/terms-agreement-form.dto';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { responseExampleForTermsAgreement } from 'src/constants/swagger';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
+import { TermsAgreementEnum } from 'src/types/terms-agreements.type';
 
 @ApiTags('Terms-Agreement')
 @Controller('terms-agreements')
@@ -48,7 +48,7 @@ export class TermsAgreementsController {
   })
   @ApiResponse(responseExampleForTermsAgreement.getTermsAgreement)
   getTermsAgreement(
-    @Param('termsAgreementId', ParseUUIDPipe) termsAgreementId: string,
+    @Param('termsAgreementId') termsAgreementId: TermsAgreementEnum,
   ) {
     return this.termsAgreementsService.getTermsAgreement(termsAgreementId);
   }
@@ -59,7 +59,7 @@ export class TermsAgreementsController {
   })
   @ApiResponse(responseExampleForTermsAgreement.deleteTermsAgreement)
   deleteTermsAgreement(
-    @Param('termsAgreementId', ParseUUIDPipe) termsAgreementId: string,
+    @Param('termsAgreementId') termsAgreementId: TermsAgreementEnum,
   ) {
     return this.termsAgreementsService.deleteTermsAgreement(termsAgreementId);
   }

--- a/src/terms-agreements/terms-agreements.entity.ts
+++ b/src/terms-agreements/terms-agreements.entity.ts
@@ -1,22 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { IsBoolean, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { TermsAgreementEnum } from 'src/types/terms-agreements.type';
 import { UserToTermsAgreementEntity } from 'src/user-to-terms-agreements/user-to-terms-agreements.entity';
-import {
-  Column,
-  Entity,
-  Index,
-  OneToMany,
-  PrimaryGeneratedColumn,
-} from 'typeorm';
+import { Column, Entity, Index, OneToMany, PrimaryColumn } from 'typeorm';
 
 @Index('termsAgreementId', ['id'], { unique: true })
 @Entity({
   name: 'TERMS_AGREEMENT',
 })
 export class TermsAgreementEntity {
-  @IsUUID()
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+  @ApiProperty()
+  @IsEnum(TermsAgreementEnum)
+  @PrimaryColumn({ enum: TermsAgreementEnum })
+  id: TermsAgreementEnum;
 
   @ApiProperty()
   @IsString()

--- a/src/terms-agreements/terms-agreements.service.ts
+++ b/src/terms-agreements/terms-agreements.service.ts
@@ -1,9 +1,14 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { TermsAgreementEntity } from './terms-agreements.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { TermsAgreementFormDTO } from './dto/terms-agreemtn-form.dto';
+import { TermsAgreementFormDTO } from './dto/terms-agreement-form.dto';
 import { termsAgreementExceptionMessage } from 'src/constants/exceptionMessage';
+import { TermsAgreementEnum } from 'src/types/terms-agreements.type';
 
 @Injectable()
 export class TermsAgreementsService {
@@ -12,7 +17,7 @@ export class TermsAgreementsService {
     private readonly termsAgreementRepository: Repository<TermsAgreementEntity>,
   ) {}
 
-  async findById(id: string) {
+  async findById(id: TermsAgreementEnum) {
     return await this.termsAgreementRepository.findOneBy({ id });
   }
 
@@ -40,6 +45,12 @@ export class TermsAgreementsService {
   }
 
   async createTermsAgreement(termsAgreementFormDTO: TermsAgreementFormDTO) {
+    const termsAgreement = await this.findById(termsAgreementFormDTO.id);
+
+    if (termsAgreement) {
+      throw new BadRequestException('중복된 약관동의 아이디입니다.');
+    }
+
     const newTermsAgreement = this.termsAgreementRepository.create(
       termsAgreementFormDTO,
     );
@@ -51,7 +62,7 @@ export class TermsAgreementsService {
     return await this.termsAgreementRepository.find();
   }
 
-  async getTermsAgreement(termsAgreementId: string) {
+  async getTermsAgreement(termsAgreementId: TermsAgreementEnum) {
     const targetTermsAgreement = await this.findById(termsAgreementId);
 
     if (!targetTermsAgreement) {
@@ -63,7 +74,7 @@ export class TermsAgreementsService {
     return targetTermsAgreement;
   }
 
-  async deleteTermsAgreement(termsAgreementId: string) {
+  async deleteTermsAgreement(termsAgreementId: TermsAgreementEnum) {
     const targetTermsAgreement = await this.findById(termsAgreementId);
 
     if (!targetTermsAgreement) {

--- a/src/types/terms-agreements.type.ts
+++ b/src/types/terms-agreements.type.ts
@@ -1,0 +1,5 @@
+export enum TermsAgreementEnum {
+  service = 'service',
+  privacy = 'privacy',
+  marketing = 'marketing',
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #64

<br />

## 🗒 작업 목록

- [x] 약관동의 테이블 id 변경 (uuid -> enum)
    - [x]  service, privacy, marketing
- [x]  swagger 최신화

<br />

## 🧐 PR Point

- 기존 uuid였던 약관동의 데이터의 id를 사용자 정의 enum으로 변경하는 작업을 진행하였습니다.
- 약관동의의 아이디의 경우 `service`, `privacy`, `marketing` 의 값으로 enum을 만들어 적용해두어, 다른 값이 들어오는 경우 exception을 반환하도록 하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/18401a17-706c-40b1-854d-33299087da58)


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
