### PR TITLE
뱃지 획득 함수 개선

### DIFF
--- a/src/bookmarks/bookmarks.module.ts
+++ b/src/bookmarks/bookmarks.module.ts
@@ -4,13 +4,13 @@ import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { DiariesModule } from 'src/diaries/diaries.module';
 import { BookmarkEntity } from './bookmarks.entity';
 import { BookmarksService } from './bookmarks.service';
-import { BadgesModule } from 'src/badges/badges.module';
+import { UserToBadgesModule } from 'src/user-to-badges/user-to-badges.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([BookmarkEntity, DiaryEntity]),
     forwardRef(() => DiariesModule),
-    BadgesModule,
+    UserToBadgesModule,
   ],
   providers: [BookmarksService],
   exports: [BookmarksService],

--- a/src/bookmarks/bookmarks.service.ts
+++ b/src/bookmarks/bookmarks.service.ts
@@ -6,9 +6,8 @@ import { DiariesService } from 'src/diaries/diaries.service';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { Repository } from 'typeorm';
 import { BookmarkEntity } from './bookmarks.entity';
-import { BadgeEntity } from 'src/badges/badges.entity';
-import { BadgesService } from 'src/badges/badges.service';
-import { BadgeCode } from 'src/types/badges.type';
+import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
+import { BadgeAcquisitionConditionForBookmark } from 'src/constants/badgeAcquisitionCondition';
 
 @Injectable()
 export class BookmarksService {
@@ -16,7 +15,7 @@ export class BookmarksService {
     @InjectRepository(BookmarkEntity)
     private readonly bookmarkRepository: Repository<BookmarkEntity>,
     private readonly diariesSerivce: DiariesService,
-    private readonly badgesService: BadgesService,
+    private readonly userToBadgesService: UserToBadgesService,
   ) {}
 
   async findBookmarkByUserAndDiary(user: UserDTO, diary: DiaryEntity) {
@@ -52,14 +51,12 @@ export class BookmarksService {
       .where('user.id = :userId', { userId: user.id })
       .getCount();
 
-    let badgeToGet: BadgeEntity;
-
-    // FIXME: 이미 획득한 경우 예외 처리
-    // FIXME: 획득 조건 상수 혹은 함수로 분리
-    if (registerBookmarkCount === 10) {
-      badgeToGet = await this.badgesService.findById(BadgeCode.bookmark);
-    }
-
+    // 뱃지 획득 조건을 추가하고 싶은 경우 /src/constants/badgeAcquisitionCondition.ts에 추가
+    const badgeToGet = await this.userToBadgesService.achievedBadge(
+      user,
+      registerBookmarkCount,
+      BadgeAcquisitionConditionForBookmark,
+    );
     return { message: '북마크가 등록되었습니다.', badge: badgeToGet || null };
   }
 

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -3,12 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { CommentEntity } from './comments.entity';
 import { CommentsService } from './comments.service';
-import { BadgesModule } from 'src/badges/badges.module';
+import { UserToBadgesModule } from 'src/user-to-badges/user-to-badges.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([CommentEntity, DiaryEntity]),
-    BadgesModule,
+    UserToBadgesModule,
   ],
   providers: [CommentsService],
   exports: [CommentsService],

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -13,8 +13,8 @@ import { UserDTO } from 'src/users/dto/user.dto';
 import { Repository } from 'typeorm';
 import { CommentEntity } from './comments.entity';
 import { CommentFormDTO } from './dto/comment-form.dto';
-import { BadgeCode } from 'src/types/badges.type';
 import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
+import { BadgeAcquisitionConditionForComment } from 'src/constants/badgeAcquisitionCondition';
 
 @Injectable()
 export class CommentsService {
@@ -53,29 +53,17 @@ export class CommentsService {
       .where('commenter.id = :userId', { userId: accessedUser.id })
       .getCount();
 
-    const badgeToGet = await this.achievedBadge(
+    // 뱃지 획득 조건을 추가하고 싶은 경우 /src/constants/badgeAcquisitionCondition.ts에 추가
+    const badgeToGet = await this.userToBadgesService.achievedBadge(
       accessedUser,
       totalCommentCount,
+      BadgeAcquisitionConditionForComment,
     );
 
     return {
       comment: newComment,
       badge: badgeToGet,
     };
-  }
-
-  // FIXME: 이미 획득한 경우 예외 처리
-  // FIXME: 획득 조건 상수 혹은 함수로 분리
-  private async achievedBadge(user: UserDTO, conditionCount: number) {
-    switch (conditionCount) {
-      case 10:
-        return await this.userToBadgesService.saveUserToBadge(
-          user,
-          BadgeCode.comment,
-        );
-      default:
-        return null;
-    }
   }
 
   async getCommentList(diaryId: string, take?: number, skip?: number) {

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -13,9 +13,8 @@ import { UserDTO } from 'src/users/dto/user.dto';
 import { Repository } from 'typeorm';
 import { CommentEntity } from './comments.entity';
 import { CommentFormDTO } from './dto/comment-form.dto';
-import { BadgeEntity } from 'src/badges/badges.entity';
-import { BadgesService } from 'src/badges/badges.service';
 import { BadgeCode } from 'src/types/badges.type';
+import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
 
 @Injectable()
 export class CommentsService {
@@ -24,7 +23,7 @@ export class CommentsService {
     private readonly commentRepository: Repository<CommentEntity>,
     @InjectRepository(DiaryEntity)
     private readonly diaryRepository: Repository<DiaryEntity>,
-    private readonly badgesService: BadgesService,
+    private readonly userToBadgesService: UserToBadgesService,
   ) {}
 
   async createComment(
@@ -48,24 +47,35 @@ export class CommentsService {
     await this.diaryRepository.save(targetDiary);
     await this.commentRepository.save(newComment);
 
-    const commentWriteCount = await this.commentRepository
+    const totalCommentCount = await this.commentRepository
       .createQueryBuilder('comment')
       .leftJoin('comment.commenter', 'commenter')
       .where('commenter.id = :userId', { userId: accessedUser.id })
       .getCount();
 
-    let badgeToGet: BadgeEntity;
-
-    // FIXME: 이미 획득한 경우 예외 처리
-    // FIXME: 획득 조건 상수 혹은 함수로 분리
-    if (commentWriteCount === 10) {
-      badgeToGet = await this.badgesService.findById(BadgeCode.comment);
-    }
+    const badgeToGet = await this.achievedBadge(
+      accessedUser,
+      totalCommentCount,
+    );
 
     return {
       comment: newComment,
-      badge: badgeToGet || null,
+      badge: badgeToGet,
     };
+  }
+
+  // FIXME: 이미 획득한 경우 예외 처리
+  // FIXME: 획득 조건 상수 혹은 함수로 분리
+  private async achievedBadge(user: UserDTO, conditionCount: number) {
+    switch (conditionCount) {
+      case 10:
+        return await this.userToBadgesService.saveUserToBadge(
+          user,
+          BadgeCode.comment,
+        );
+      default:
+        return null;
+    }
   }
 
   async getCommentList(diaryId: string, take?: number, skip?: number) {

--- a/src/constants/badgeAcquisitionCondition.ts
+++ b/src/constants/badgeAcquisitionCondition.ts
@@ -1,0 +1,36 @@
+import { BadgeAcquisitionCondition, BadgeCode } from 'src/types/badges.type';
+
+export const BadgeAcquisitionConditionForDiary: BadgeAcquisitionCondition[] = [
+  {
+    conditionCount: 1,
+    badgeCode: BadgeCode.writer_0,
+  },
+  {
+    conditionCount: 10,
+    badgeCode: BadgeCode.writer_1,
+  },
+];
+
+export const BadgeAcquisitionConditionForComment: BadgeAcquisitionCondition[] =
+  [
+    {
+      conditionCount: 10,
+      badgeCode: BadgeCode.comment,
+    },
+  ];
+
+export const BadgeAcquisitionConditionForFavorite: BadgeAcquisitionCondition[] =
+  [
+    {
+      conditionCount: 10,
+      badgeCode: BadgeCode.heart,
+    },
+  ];
+
+export const BadgeAcquisitionConditionForBookmark: BadgeAcquisitionCondition[] =
+  [
+    {
+      conditionCount: 10,
+      badgeCode: BadgeCode.bookmark,
+    },
+  ];

--- a/src/diaries/diaries.module.ts
+++ b/src/diaries/diaries.module.ts
@@ -8,7 +8,6 @@ import { DiaryEntity } from './diaries.entity';
 import { DiariesService } from './diaries.service';
 import { CommentsModule } from 'src/comments/comments.module';
 import { UserToBadgesModule } from 'src/user-to-badges/user-to-badges.module';
-import { BadgesModule } from 'src/badges/badges.module';
 
 @Module({
   imports: [
@@ -17,7 +16,6 @@ import { BadgesModule } from 'src/badges/badges.module';
     BookmarksModule,
     CommentsModule,
     UserToBadgesModule,
-    BadgesModule,
   ],
   controllers: [DiariesController],
   providers: [DiariesService, AwsService],

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -12,9 +12,7 @@ import { DiaryEntity } from './diaries.entity';
 import { DiaryFormDTO } from './dto/diary-form.dto';
 import { DEFAULT_SKIP, DEFAULT_TAKE } from 'src/constants/page';
 import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
-import { BadgesService } from 'src/badges/badges.service';
 import { BadgeCode } from 'src/types/badges.type';
-import { BadgeEntity } from 'src/badges/badges.entity';
 
 @Injectable()
 export class DiariesService {
@@ -23,7 +21,6 @@ export class DiariesService {
     private readonly diaryRepository: Repository<DiaryEntity>,
     private readonly awsService: AwsService,
     private readonly userToBadgesService: UserToBadgesService,
-    private readonly badgesService: BadgesService,
   ) {}
   async uploadImg(file: Express.Multer.File) {
     const uploadInfo = await this.awsService.uploadFileToS3('diaries', file);
@@ -173,26 +170,29 @@ export class DiariesService {
       .where('author.id = :authorId', { authorId: author.id })
       .getCount();
 
-    let badgeToGet: BadgeEntity;
-
-    switch (writeCount) {
-      case 1:
-        badgeToGet = await this.badgesService.findById(BadgeCode.writer_0);
-
-        break;
-      case 10:
-        badgeToGet = await this.badgesService.findById(BadgeCode.writer_1);
-        break;
-    }
-
-    if (badgeToGet) {
-      this.userToBadgesService.saveUserToBadge(author, badgeToGet);
-    }
+    const badgeToGet = await this.achievedBadge(author, writeCount);
 
     return {
       diary: newDiary,
-      badge: badgeToGet || null,
+      badge: badgeToGet,
     };
+  }
+
+  private async achievedBadge(user: UserDTO, conditionCount: number) {
+    switch (conditionCount) {
+      case 1:
+        return await this.userToBadgesService.saveUserToBadge(
+          user,
+          BadgeCode.writer_0,
+        );
+      case 10:
+        return await this.userToBadgesService.saveUserToBadge(
+          user,
+          BadgeCode.writer_1,
+        );
+      default:
+        return null;
+    }
   }
 
   async update(id: string, diaryFormDto: DiaryFormDTO, accessUser: UserDTO) {

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -12,7 +12,7 @@ import { DiaryEntity } from './diaries.entity';
 import { DiaryFormDTO } from './dto/diary-form.dto';
 import { DEFAULT_SKIP, DEFAULT_TAKE } from 'src/constants/page';
 import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
-import { BadgeCode } from 'src/types/badges.type';
+import { BadgeAcquisitionConditionForDiary } from 'src/constants/badgeAcquisitionCondition';
 
 @Injectable()
 export class DiariesService {
@@ -170,29 +170,17 @@ export class DiariesService {
       .where('author.id = :authorId', { authorId: author.id })
       .getCount();
 
-    const badgeToGet = await this.achievedBadge(author, writeCount);
+    // 뱃지 획득 조건을 추가하고 싶은 경우 /src/constants/badgeAcquisitionCondition.ts에 추가
+    const badgeToGet = await this.userToBadgesService.achievedBadge(
+      author,
+      writeCount,
+      BadgeAcquisitionConditionForDiary,
+    );
 
     return {
       diary: newDiary,
       badge: badgeToGet,
     };
-  }
-
-  private async achievedBadge(user: UserDTO, conditionCount: number) {
-    switch (conditionCount) {
-      case 1:
-        return await this.userToBadgesService.saveUserToBadge(
-          user,
-          BadgeCode.writer_0,
-        );
-      case 10:
-        return await this.userToBadgesService.saveUserToBadge(
-          user,
-          BadgeCode.writer_1,
-        );
-      default:
-        return null;
-    }
   }
 
   async update(id: string, diaryFormDto: DiaryFormDTO, accessUser: UserDTO) {

--- a/src/favorites/favorites.module.ts
+++ b/src/favorites/favorites.module.ts
@@ -3,12 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { FavoriteEntity } from './favorites.entity';
 import { FavoritesService } from './favorites.service';
-import { BadgesModule } from 'src/badges/badges.module';
+import { UserToBadgesModule } from 'src/user-to-badges/user-to-badges.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([DiaryEntity, FavoriteEntity]),
-    BadgesModule,
+    UserToBadgesModule,
   ],
   providers: [FavoritesService],
   exports: [FavoritesService],

--- a/src/favorites/favorites.service.ts
+++ b/src/favorites/favorites.service.ts
@@ -5,8 +5,8 @@ import { favoriteExceptionMessage } from 'src/constants/exceptionMessage';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { FavoriteEntity } from './favorites.entity';
-import { BadgeCode } from 'src/types/badges.type';
 import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
+import { BadgeAcquisitionConditionForFavorite } from 'src/constants/badgeAcquisitionCondition';
 
 @Injectable()
 export class FavoritesService {
@@ -55,23 +55,14 @@ export class FavoritesService {
       .where('user.id = :userId', { userId: user.id })
       .getCount();
 
-    const badgeToGet = await this.achievedBadge(user, registerFavoriteCount);
+    // 뱃지 획득 조건을 추가하고 싶은 경우 /src/constants/badgeAcquisitionCondition.ts에 추가
+    const badgeToGet = await this.userToBadgesService.achievedBadge(
+      user,
+      registerFavoriteCount,
+      BadgeAcquisitionConditionForFavorite,
+    );
 
     return { message: '좋아요가 등록되었습니다.', badge: badgeToGet };
-  }
-
-  // FIXME: 이미 획득한 경우 예외 처리
-  // FIXME: 획득 조건 상수 혹은 함수로 분리
-  private async achievedBadge(user: UserDTO, conditionCount: number) {
-    switch (conditionCount) {
-      case 10:
-        return await this.userToBadgesService.saveUserToBadge(
-          user,
-          BadgeCode.heart,
-        );
-      default:
-        return null;
-    }
   }
 
   async unregister(diaryId: string, user: UserDTO) {

--- a/src/favorites/favorites.service.ts
+++ b/src/favorites/favorites.service.ts
@@ -5,9 +5,8 @@ import { favoriteExceptionMessage } from 'src/constants/exceptionMessage';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { FavoriteEntity } from './favorites.entity';
-import { BadgeEntity } from 'src/badges/badges.entity';
 import { BadgeCode } from 'src/types/badges.type';
-import { BadgesService } from 'src/badges/badges.service';
+import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
 
 @Injectable()
 export class FavoritesService {
@@ -16,7 +15,7 @@ export class FavoritesService {
     private readonly favoriteRepository: Repository<FavoriteEntity>,
     @InjectRepository(DiaryEntity)
     private readonly diaryRepository: Repository<DiaryEntity>,
-    private readonly badgesService: BadgesService,
+    private readonly userToBadgesService: UserToBadgesService,
   ) {}
 
   async register(diaryId: string, user: UserDTO) {
@@ -56,15 +55,23 @@ export class FavoritesService {
       .where('user.id = :userId', { userId: user.id })
       .getCount();
 
-    let badgeToGet: BadgeEntity;
+    const badgeToGet = await this.achievedBadge(user, registerFavoriteCount);
 
-    // FIXME: 이미 획득한 경우 예외 처리
-    // FIXME: 획득 조건 상수 혹은 함수로 분리
-    if (registerFavoriteCount === 10) {
-      badgeToGet = await this.badgesService.findById(BadgeCode.heart);
+    return { message: '좋아요가 등록되었습니다.', badge: badgeToGet };
+  }
+
+  // FIXME: 이미 획득한 경우 예외 처리
+  // FIXME: 획득 조건 상수 혹은 함수로 분리
+  private async achievedBadge(user: UserDTO, conditionCount: number) {
+    switch (conditionCount) {
+      case 10:
+        return await this.userToBadgesService.saveUserToBadge(
+          user,
+          BadgeCode.heart,
+        );
+      default:
+        return null;
     }
-
-    return { message: '좋아요가 등록되었습니다.', badge: badgeToGet || null };
   }
 
   async unregister(diaryId: string, user: UserDTO) {

--- a/src/types/badges.type.ts
+++ b/src/types/badges.type.ts
@@ -27,3 +27,8 @@ export interface BadgeListByUserResponse {
     createdAt: Date;
   } | null;
 }
+
+export interface BadgeAcquisitionCondition {
+  conditionCount: number;
+  badgeCode: BadgeCode;
+}

--- a/src/user-to-badges/user-to-badges.module.ts
+++ b/src/user-to-badges/user-to-badges.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UserToBadgesService } from './user-to-badges.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserToBadgeEntity } from './user-to-badges.entity';
+import { BadgesModule } from 'src/badges/badges.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserToBadgeEntity])],
+  imports: [TypeOrmModule.forFeature([UserToBadgeEntity]), BadgesModule],
   providers: [UserToBadgesService],
   exports: [UserToBadgesService],
 })

--- a/src/user-to-badges/user-to-badges.service.ts
+++ b/src/user-to-badges/user-to-badges.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { UserToBadgeEntity } from './user-to-badges.entity';
 import { Repository } from 'typeorm';
 import { UserDTO } from 'src/users/dto/user.dto';
-import { BadgeCode } from 'src/types/badges.type';
+import { BadgeCode, BadgeAcquisitionCondition } from 'src/types/badges.type';
 import { BadgesService } from 'src/badges/badges.service';
 
 @Injectable()
@@ -35,5 +35,25 @@ export class UserToBadgesService {
     }
 
     return badge;
+  }
+
+  async achievedBadge(
+    user: UserDTO,
+    currentConditionCount: number,
+    badgeAcquisitionConditionList: BadgeAcquisitionCondition[],
+  ) {
+    const targetAcquisitionCondition = badgeAcquisitionConditionList.find(
+      (badgeAcquisitionCondition) =>
+        badgeAcquisitionCondition.conditionCount === currentConditionCount,
+    );
+
+    if (!targetAcquisitionCondition) {
+      return null;
+    }
+
+    return await this.saveUserToBadge(
+      user,
+      targetAcquisitionCondition.badgeCode,
+    );
   }
 }

--- a/src/user-to-badges/user-to-badges.service.ts
+++ b/src/user-to-badges/user-to-badges.service.ts
@@ -3,21 +3,25 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { UserToBadgeEntity } from './user-to-badges.entity';
 import { Repository } from 'typeorm';
 import { UserDTO } from 'src/users/dto/user.dto';
-import { BadgeEntity } from 'src/badges/badges.entity';
+import { BadgeCode } from 'src/types/badges.type';
+import { BadgesService } from 'src/badges/badges.service';
 
 @Injectable()
 export class UserToBadgesService {
   constructor(
     @InjectRepository(UserToBadgeEntity)
     private readonly userToBadgeRepository: Repository<UserToBadgeEntity>,
+    private readonly badgesService: BadgesService,
   ) {}
 
-  async saveUserToBadge(user: UserDTO, badge: BadgeEntity) {
+  async saveUserToBadge(user: UserDTO, badgeCode: BadgeCode) {
     const pinnedCount = await this.userToBadgeRepository
       .createQueryBuilder('userToBadge')
       .where('userToBadge.user.id = :userId', { userId: user.id })
       .andWhere('userToBadge.isPinned = true')
       .getCount();
+
+    const badge = await this.badgesService.findById(badgeCode);
 
     const newUserToBadge = this.userToBadgeRepository.create({
       user,
@@ -30,6 +34,6 @@ export class UserToBadgesService {
       throw new Error('뱃지 이력 생성 도중 에러');
     }
 
-    return true;
+    return badge;
   }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #80

<br />

## 🗒 작업 목록

- [x] 뱃지 획득 로직이 비슷하여 하나로 통일
- [x] DI되었던 badge service 제거에 따른 module import 제거
<br />

## 🧐 PR Point

- 비슷한 로직이 여러 곳에서 사용되고 있어 하나의 로직으로 통일하였습니다.
- 해당 로직을 사용하기 위한 기본 전처리 데이터 타입과 각 조건에 맞는 상수를 정의하여 해당 메소드의 파라미터로 활용하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
