### PR TITLE
뱃지 pinned API 개발

### DIFF
--- a/src/badges/badges.controller.ts
+++ b/src/badges/badges.controller.ts
@@ -4,8 +4,10 @@ import {
   Delete,
   Get,
   Param,
+  ParseBoolPipe,
   Post,
   Put,
+  Query,
   UploadedFile,
   UseFilters,
   UseGuards,
@@ -32,12 +34,16 @@ import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { BadgeFormDTO } from './dto/badge-form.dto';
 import { BadgeCode } from 'src/types/badges.type';
+import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
 
 @ApiTags('Badge')
 @Controller('badges')
 @UseFilters(HttpApiExceptionFilter)
 export class BadgesController {
-  constructor(private readonly badgesService: BadgesService) {}
+  constructor(
+    private readonly badgesService: BadgesService,
+    private readonly userToBadgesService: UserToBadgesService,
+  ) {}
 
   @Post('upload-image')
   @ApiConsumes('multipart/form-data')
@@ -103,8 +109,11 @@ export class BadgesController {
   @ApiBearerAuth('access-token')
   @ApiResponse(responseExampleForBadge.getBadgeListByUsername)
   @UseGuards(JwtAuthGuard)
-  getBadgeListByUsername(@Param('username') username: string) {
-    return this.badgesService.getBadgeListByUsername(username);
+  getBadgeListByUsername(
+    @Param('username') username: string,
+    @Query('onlyPinned', ParseBoolPipe) onlyPinned?: boolean,
+  ) {
+    return this.badgesService.getBadgeListByUsername(username, onlyPinned);
   }
 
   @Put(':badgeId')
@@ -128,7 +137,10 @@ export class BadgesController {
   @ApiBearerAuth('access-token')
   @ApiResponse(responseExampleForBadge.deleteBadge)
   @UseGuards(JwtAuthGuard)
-  deleteBadge(@Param('badgeId') badgeId: BadgeCode) {
+  deleteBadge(
+    @Param('badgeId')
+    badgeId: BadgeCode,
+  ) {
     return this.badgesService.deleteBadge(badgeId);
   }
 }

--- a/src/badges/badges.controller.ts
+++ b/src/badges/badges.controller.ts
@@ -5,6 +5,8 @@ import {
   Get,
   Param,
   ParseBoolPipe,
+  ParseEnumPipe,
+  Patch,
   Post,
   Put,
   Query,
@@ -116,6 +118,15 @@ export class BadgesController {
     return this.badgesService.getBadgeListByUsername(username, onlyPinned);
   }
 
+  @Patch(':badgeId')
+  @UseGuards(JwtAuthGuard)
+  pinnedBadge(
+    @CurrentUser() currentUser: UserDTO,
+    @Param('badgeId', new ParseEnumPipe(BadgeCode)) badgeId: BadgeCode,
+  ) {
+    return this.userToBadgesService.pinnedBadge(currentUser, badgeId);
+  }
+
   @Put(':badgeId')
   @ApiOperation({
     summary: '뱃지 수정 (관리자)',
@@ -124,7 +135,7 @@ export class BadgesController {
   @ApiResponse(responseExampleForBadge.updateBadge)
   @UseGuards(JwtAuthGuard)
   updateBadge(
-    @Param('badgeId') badgeId: BadgeCode,
+    @Param('badgeId', new ParseEnumPipe(BadgeCode)) badgeId: BadgeCode,
     @Body() badgeFormDTO: BadgeFormDTO,
   ) {
     return this.badgesService.updateBadge(badgeId, badgeFormDTO);
@@ -138,7 +149,7 @@ export class BadgesController {
   @ApiResponse(responseExampleForBadge.deleteBadge)
   @UseGuards(JwtAuthGuard)
   deleteBadge(
-    @Param('badgeId')
+    @Param('badgeId', new ParseEnumPipe(BadgeCode))
     badgeId: BadgeCode,
   ) {
     return this.badgesService.deleteBadge(badgeId);

--- a/src/badges/badges.controller.ts
+++ b/src/badges/badges.controller.ts
@@ -119,6 +119,14 @@ export class BadgesController {
   }
 
   @Patch(':badgeId')
+  @ApiOperation({
+    summary: '뱃지 Pinned API',
+    description: `
+    API호출 직전의 isPinned 값의 반대 값으로 변경
+    ex) false였던 뱃지에서 해당 API 호출 시 true로 변경`,
+  })
+  @ApiBearerAuth('access-token')
+  @ApiResponse(responseExampleForBadge.pinnedBadge)
   @UseGuards(JwtAuthGuard)
   pinnedBadge(
     @CurrentUser() currentUser: UserDTO,

--- a/src/badges/badges.module.ts
+++ b/src/badges/badges.module.ts
@@ -1,16 +1,17 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { BadgesService } from './badges.service';
 import { BadgesController } from './badges.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BadgeEntity } from './badges.entity';
 import { AwsService } from 'src/aws.service';
-import { UserToBadgeEntity } from 'src/user-to-badges/user-to-badges.entity';
 import { UsersModule } from 'src/users/users.module';
+import { UserToBadgesModule } from 'src/user-to-badges/user-to-badges.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([BadgeEntity, UserToBadgeEntity]),
+    TypeOrmModule.forFeature([BadgeEntity]),
     UsersModule,
+    forwardRef(() => UserToBadgesModule),
   ],
   providers: [BadgesService, AwsService],
   controllers: [BadgesController],

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -37,6 +37,11 @@ export const badgeExceptionMessage = {
   EXIST_BADGE_NAME: '설정하신 뱃지 이름은 이미 존재합니다.',
 };
 
+export const userToBadgesExceptionMessage = {
+  DOES_NOT_EXIST_USER_TO_BADGE: '해당 뱃지를 획득하지 못했습니다.',
+  ONLY_SET_8: '뱃지의 최대 pinned 개수는 8개입니다.',
+};
+
 export const termsAgreementExceptionMessage = {
   DOES_NOT_EXIST_TERMS_AGREEMENT: '해당하는 약관동의는 존재하지 않습니다.',
   INVALIDATE_TERMS_AGREEMENTS: '필수 약관동의를 체크해주세요',

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -40,6 +40,7 @@ export const badgeExceptionMessage = {
 export const userToBadgesExceptionMessage = {
   DOES_NOT_EXIST_USER_TO_BADGE: '해당 뱃지를 획득하지 못했습니다.',
   ONLY_SET_8: '뱃지의 최대 pinned 개수는 8개입니다.',
+  OWNER_ONLY_PINNED: '뱃지 소유자만 pinned 할 수 있습니다.',
 };
 
 export const termsAgreementExceptionMessage = {

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -209,6 +209,7 @@ export const responseExampleForBadge = {
   }),
   updateBadge: responseTemplate(badgeResponse),
   deleteBadge: responseTemplate(deleteResponse),
+  pinnedBadge: responseTemplate(userToBadgeResponse),
 };
 
 export const responseExampleForTermsAgreement = {

--- a/src/user-to-badges/user-to-badges.module.ts
+++ b/src/user-to-badges/user-to-badges.module.ts
@@ -1,11 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { UserToBadgesService } from './user-to-badges.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserToBadgeEntity } from './user-to-badges.entity';
 import { BadgesModule } from 'src/badges/badges.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserToBadgeEntity]), BadgesModule],
+  imports: [
+    TypeOrmModule.forFeature([UserToBadgeEntity]),
+    forwardRef(() => BadgesModule),
+  ],
   providers: [UserToBadgesService],
   exports: [UserToBadgesService],
 })

--- a/src/user-to-badges/user-to-badges.service.ts
+++ b/src/user-to-badges/user-to-badges.service.ts
@@ -76,6 +76,11 @@ export class UserToBadgesService {
         userToBadgesExceptionMessage.DOES_NOT_EXIST_USER_TO_BADGE,
       );
 
+    if (targetUserToBadge.user.id !== accessedUser.id)
+      throw new BadRequestException(
+        userToBadgesExceptionMessage.OWNER_ONLY_PINNED,
+      );
+
     const pinnedCount = await this.userToBadgeRepository
       .createQueryBuilder('userToBadge')
       .leftJoin('userToBadge.user', 'user')

--- a/src/user-to-badges/user-to-badges.service.ts
+++ b/src/user-to-badges/user-to-badges.service.ts
@@ -1,10 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserToBadgeEntity } from './user-to-badges.entity';
 import { Repository } from 'typeorm';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { BadgeCode, BadgeAcquisitionCondition } from 'src/types/badges.type';
 import { BadgesService } from 'src/badges/badges.service';
+import { userToBadgesExceptionMessage } from 'src/constants/exceptionMessage';
 
 @Injectable()
 export class UserToBadgesService {
@@ -55,5 +60,35 @@ export class UserToBadgesService {
       user,
       targetAcquisitionCondition.badgeCode,
     );
+  }
+
+  async pinnedBadge(accessedUser: UserDTO, badgeId: BadgeCode) {
+    const targetUserToBadge = await this.userToBadgeRepository
+      .createQueryBuilder('userToBadges')
+      .leftJoin('userToBadges.user', 'user')
+      .leftJoin('userToBadges.badge', 'badge')
+      .where('user.id = :userId', { userId: accessedUser.id })
+      .andWhere('badge.id = :badgeId', { badgeId })
+      .getOne();
+
+    if (!targetUserToBadge)
+      throw new NotFoundException(
+        userToBadgesExceptionMessage.DOES_NOT_EXIST_USER_TO_BADGE,
+      );
+
+    const pinnedCount = await this.userToBadgeRepository
+      .createQueryBuilder('userToBadge')
+      .leftJoin('userToBadge.user', 'user')
+      .where('user.id = :userId', { userId: accessedUser.id })
+      .andWhere('userToBadge.isPinned = true')
+      .getCount();
+
+    if (targetUserToBadge.isPinned === false && pinnedCount === 8)
+      throw new BadRequestException(userToBadgesExceptionMessage.ONLY_SET_8);
+
+    targetUserToBadge.isPinned = !targetUserToBadge.isPinned;
+    this.userToBadgeRepository.update(targetUserToBadge.id, targetUserToBadge);
+
+    return targetUserToBadge;
   }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #78

<br />

## 🗒 작업 목록

- [x] 뱃지 Pinned 속성의 값 변경 API 개발
    - pinned max 8 예외 처리
- [x] 유저별 뱃지 전체 조회 API 수정
- [x] pinned된 뱃지만 호출하는 옵션 개발

<br />

## 🧐 PR Point

- 유저별 뱃지 조회 API에서 onlyPinned 의 query parameter 값으로 프로필에서 보여질 pinned된 뱃지만 조회할 수 있는 기능 추가
- pinned 뱃지 API 개발
    - 해당 API 호출 전 설정되어 있는 isPinned의 반대 값으로 변경

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- `onlyPinned` 속성을 query parameter로 설정
![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/342ef1c9-a7c1-42a7-9ebc-fe7cd0d68801)

- pinned 뱃지 API
![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/82816a3e-5c68-4574-96dd-a979d5a6506b)


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
