### PR TITLE
일기 검색 기능 구현

### DIFF
--- a/src/constants/badgeAcquisitionCondition.ts
+++ b/src/constants/badgeAcquisitionCondition.ts
@@ -3,11 +3,11 @@ import { BadgeAcquisitionCondition, BadgeCode } from 'src/types/badges.type';
 export const BadgeAcquisitionConditionForDiary: BadgeAcquisitionCondition[] = [
   {
     conditionCount: 1,
-    badgeCode: BadgeCode.writer_0,
+    badgeCode: BadgeCode.steady_0,
   },
   {
     conditionCount: 10,
-    badgeCode: BadgeCode.writer_1,
+    badgeCode: BadgeCode.steady_1,
   },
 ];
 

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -77,6 +77,7 @@ export class DiariesController {
   @ApiQuery({ name: 'username', required: false, type: 'string' })
   @ApiQuery({ name: 'take', required: false, type: 'number' })
   @ApiQuery({ name: 'skip', required: false, type: 'number' })
+  @ApiQuery({ name: 'searchKeyword', required: false, type: 'string' })
   @ApiResponse(responseExampleForDiary.getDiaries)
   @UseGuards(JwtAuthGuard) // FIXME: 비로그인 상태 로직 생각하기
   getDiaries(

--- a/src/diaries/diaries.controller.ts
+++ b/src/diaries/diaries.controller.ts
@@ -84,8 +84,15 @@ export class DiariesController {
     @Query('username') username?: string,
     @Query('take') take?: number | typeof NaN,
     @Query('skip') skip?: number | typeof NaN,
+    @Query('searchKeyword') searchKeyword?: string,
   ) {
-    return this.diariesService.getDiaries(currentUser, username, take, skip);
+    return this.diariesService.getDiaries(
+      currentUser,
+      username,
+      searchKeyword,
+      take,
+      skip,
+    );
   }
 
   @Get('bookmark/:username')

--- a/src/types/badges.type.ts
+++ b/src/types/badges.type.ts
@@ -1,8 +1,8 @@
 export enum BadgeCode {
-  writer_0 = 'writer_0',
-  writer_1 = 'writer_1',
-  writer_2 = 'writer_2',
-  writer_3 = 'writer_3',
+  steady_0 = 'steady_0',
+  steady_1 = 'steady_1',
+  steady_2 = 'steady_2',
+  steady_3 = 'steady_3',
   new_bie = 'new_bie',
   bookmark = 'bookmark',
   heart = 'heart',


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #86

<br />

## 🗒 작업 목록

- [x] 일기 리스트 조회 API 수정(검색 기능 추가)
- [x] swagger 최신화

<br />

## 🧐 PR Point

- 기존 일기 리스트 조회 API에서 searchKeyword를 추가하였습니다.
- 일기 조회 시 유저 이름, 일기 타이틀, 일기 내용 중 searchKeyword에 맞는 일기를 반환해줍니다.
- 검색의 대소문자를 구분하지 않고 조회합니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/ba56798d-4553-4952-8687-39eb987c1151)

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
