### PR TITLE
잔디 그래프 용 API 개발

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { BadgesModule } from './badges/badges.module';
 import { TermsAgreementsModule } from './terms-agreements/terms-agreements.module';
 import { UserToTermsAgreementsModule } from './user-to-terms-agreements/user-to-terms-agreements.module';
 import { UserToBadgesModule } from './user-to-badges/user-to-badges.module';
+import { HeatmapModule } from './heatmap/heatmap.module';
 
 const typeOrmModuleOptions = {
   useFactory: async (): Promise<TypeOrmModuleOptions> => {
@@ -50,6 +51,7 @@ const typeOrmModuleOptions = {
     TermsAgreementsModule,
     UserToTermsAgreementsModule,
     UserToBadgesModule,
+    HeatmapModule,
   ],
   controllers: [AppController],
   providers: [AppService, AwsService],

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -53,3 +53,7 @@ export const exceptionMessage = {
   ONLY_ADMIN: '해당 API는 관리자 계정만 요청 가능합니다.',
   INCORRECT_KEY: 'incorrect key value',
 };
+
+export const heatmapExceptionMessage = {
+  ONLY_DATE_TYPE: 'Date 타입 포맷의 요청만 가능합니다.',
+};

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -221,4 +221,14 @@ export const responseExampleForTermsAgreement = {
 
 export const responseExampleForHeatmap = {
   graphData: responseTemplate([{ date: 'Date', activityCount: 'number' }]),
+  getUserActivityHistory: responseTemplate({
+    date: 'date',
+    activityCount: 'number',
+    activities: {
+      diaries: [diaryResponse],
+    },
+    diaryCount: 'number',
+    commentCount: 'number',
+    randomMatchingCount: 'number',
+  }),
 };

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -218,3 +218,7 @@ export const responseExampleForTermsAgreement = {
   getTermsAgreement: responseTemplate(termsAgreementResponse),
   deleteTermsAgreement: responseTemplate(deleteResponse),
 };
+
+export const responseExampleForHeatmap = {
+  graphData: responseTemplate([{ date: 'Date', activityCount: 'number' }]),
+};

--- a/src/heatmap/heatmap.controller.ts
+++ b/src/heatmap/heatmap.controller.ts
@@ -9,6 +9,7 @@ import {
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -39,6 +40,18 @@ export class HeatmapController {
 
   @Get('/graph/:username/:dateString')
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: '날짜 별 유저 활동 내역 조회 API',
+    description:
+      '일기의 경우 공개 여부에 따라 응답(response) 구조 중 diaries에는 공개한 일기만 담겨져있습니다. diaryCount는 공개 여부와 상관없이 해당 날짜에 작성한 일기의 개수가 반환됩니다.',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiResponse(responseExampleForHeatmap.getUserActivityHistory)
+  @ApiParam({
+    name: 'dateString',
+    description:
+      '2023-06-25와 같은 형식도 가능합니다. 다만 **2023-06-25**와 **2023-6-25**는 다르게 쿼리가 되므로 2자리 수를 지켜주세요',
+  })
   getDetailHeatmap(
     @CurrentUser() accessedUser: UserDTO,
     @Param('username') username: string,

--- a/src/heatmap/heatmap.controller.ts
+++ b/src/heatmap/heatmap.controller.ts
@@ -1,8 +1,14 @@
 import { Controller, Get, Param, UseFilters, UseGuards } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
 import { HeatmapService } from './heatmap.service';
 import { JwtAuthGuard } from 'src/users/jwt/jwt.guard';
+import { responseExampleForHeatmap } from 'src/constants/swagger';
 
 @ApiTags('Heatmap')
 @Controller('heatmap')
@@ -11,6 +17,11 @@ export class HeatmapController {
   constructor(private readonly heatmapService: HeatmapService) {}
 
   @Get(':username')
+  @ApiOperation({
+    summary: '잔디 그래프 데이터용 API',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiResponse(responseExampleForHeatmap.graphData)
   @UseGuards(JwtAuthGuard)
   getHeatmapGraph(@Param('username') username: string) {
     return this.heatmapService.getHeatmapGraphData(username);

--- a/src/heatmap/heatmap.controller.ts
+++ b/src/heatmap/heatmap.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, UseFilters } from '@nestjs/common';
+import { Controller, Get, Param, UseFilters, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
 import { HeatmapService } from './heatmap.service';
+import { JwtAuthGuard } from 'src/users/jwt/jwt.guard';
 
 @ApiTags('Heatmap')
 @Controller('heatmap')
@@ -9,9 +10,10 @@ import { HeatmapService } from './heatmap.service';
 export class HeatmapController {
   constructor(private readonly heatmapService: HeatmapService) {}
 
-  @Get('')
-  getHeatmapGraph() {
-    return this.heatmapService.heatmapTestAPI();
+  @Get(':username')
+  @UseGuards(JwtAuthGuard)
+  getHeatmapGraph(@Param('username') username: string) {
+    return this.heatmapService.getHeatmapGraphData(username);
   }
 
   @Get('/:date')

--- a/src/heatmap/heatmap.controller.ts
+++ b/src/heatmap/heatmap.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, UseFilters } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
+import { HeatmapService } from './heatmap.service';
+
+@ApiTags('Heatmap')
+@Controller('heatmap')
+@UseFilters(HttpApiExceptionFilter)
+export class HeatmapController {
+  constructor(private readonly heatmapService: HeatmapService) {}
+
+  @Get('')
+  getHeatmapGraph() {
+    return this.heatmapService.heatmapTestAPI();
+  }
+
+  @Get('/:date')
+  getDetailHeatmap() {
+    return { message: '일자 별 활동 내역 상세 보기 API' };
+  }
+}

--- a/src/heatmap/heatmap.module.ts
+++ b/src/heatmap/heatmap.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { HeatmapService } from './heatmap.service';
+import { HeatmapController } from './heatmap.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DiaryEntity } from 'src/diaries/diaries.entity';
+import { CommentEntity } from 'src/comments/comments.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DiaryEntity, CommentEntity])],
+  providers: [HeatmapService],
+  controllers: [HeatmapController],
+  exports: [HeatmapService],
+})
+export class HeatmapModule {}

--- a/src/heatmap/heatmap.service.ts
+++ b/src/heatmap/heatmap.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CommentEntity } from 'src/comments/comments.entity';
+import { DiaryEntity } from 'src/diaries/diaries.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class HeatmapService {
+  constructor(
+    @InjectRepository(DiaryEntity)
+    private readonly diariesRepository: Repository<DiaryEntity>,
+    @InjectRepository(CommentEntity)
+    private readonly commentsRepository: Repository<CommentEntity>,
+  ) {}
+
+  async heatmapTestAPI() {
+    return 'test';
+  }
+}

--- a/src/heatmap/heatmap.service.ts
+++ b/src/heatmap/heatmap.service.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CommentEntity } from 'src/comments/comments.entity';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
+import {
+  convertDateToString,
+  generateLastOneYearDateList,
+} from 'src/utility/date';
 import { Repository } from 'typeorm';
 
 @Injectable()
@@ -13,7 +17,48 @@ export class HeatmapService {
     private readonly commentsRepository: Repository<CommentEntity>,
   ) {}
 
-  async heatmapTestAPI() {
-    return 'test';
+  async getHeatmapGraphData(username: string) {
+    const diaryCountGroupByDate = await this.diariesRepository
+      .createQueryBuilder('diary')
+      .leftJoin('diary.author', 'author')
+      .select("DATE_TRUNC('day', diary.createdAt) as date")
+      .addSelect('COUNT(*)', 'diaryCount')
+      .where('author.username = :username', { username })
+      .groupBy("DATE_TRUNC('day', diary.createdAt)")
+      .getRawMany();
+
+    console.log(diaryCountGroupByDate);
+
+    const commentCountGroupByDate = await this.commentsRepository
+      .createQueryBuilder('comment')
+      .leftJoin('comment.commenter', 'commenter')
+      .select("DATE_TRUNC('day', comment.createdAt) as date")
+      .addSelect('COUNT(*)', 'commentCount')
+      .where('commenter.username = :username', { username })
+      .groupBy("DATE_TRUNC('day', comment.createdAt)")
+      .getRawMany();
+
+    const lastOneYearDateList = generateLastOneYearDateList();
+
+    const responseData = lastOneYearDateList.map((dateString) => {
+      const diaryCountInfo = diaryCountGroupByDate.find(
+        (el) => convertDateToString(el.date) === dateString,
+      );
+      const commentCountInfo = commentCountGroupByDate.find(
+        (el) => convertDateToString(el.date) === dateString,
+      );
+
+      const diaryCount = diaryCountInfo ? +diaryCountInfo.diaryCount : 0;
+      const commentCount = commentCountInfo
+        ? +commentCountInfo.commentCount
+        : 0;
+
+      return {
+        date: new Date(dateString),
+        activityCount: diaryCount + commentCount,
+      };
+    });
+
+    return responseData;
   }
 }

--- a/src/heatmap/heatmap.service.ts
+++ b/src/heatmap/heatmap.service.ts
@@ -27,8 +27,6 @@ export class HeatmapService {
       .groupBy("DATE_TRUNC('day', diary.createdAt)")
       .getRawMany();
 
-    console.log(diaryCountGroupByDate);
-
     const commentCountGroupByDate = await this.commentsRepository
       .createQueryBuilder('comment')
       .leftJoin('comment.commenter', 'commenter')

--- a/src/utility/date.ts
+++ b/src/utility/date.ts
@@ -1,0 +1,24 @@
+export const convertDateToString = (date: Date) => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  const paddingMonth =
+    month.toString().length === 1 ? month.toString().padStart(2, '0') : month;
+  const paddingDay =
+    day.toString().length === 1 ? day.toString().padStart(2, '0') : day;
+
+  return `${year}-${paddingMonth}-${paddingDay}`;
+};
+
+export const generateLastOneYearDateList = () => {
+  const toDate = new Date();
+
+  const lastOneYearDateList = Array.from({ length: 365 }, (_, i) => {
+    const pastDate = new Date();
+    pastDate.setDate(toDate.getDate() - i);
+    return convertDateToString(pastDate);
+  });
+
+  return lastOneYearDateList;
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #issue_number

<br />

## 🗒 작업 목록

- [x] heatmap api 초기 셋팅
    - [x] module, service, controller
- [x] heatmap graph 용 API
- [x] 일자 별 상세 조회 API
- [x] swagger 적용

<br />

## 🧐 PR Point

- `/heatmap/graph/{username}` API의 경우 heatmap graph에 필요한 데이터를 반환하는 API입니다. 응답 데이터 구조는 아래와 같습니다.
```json
{
  "success": true,
  "data": [
    {
      "date": "Date",
      "activityCount": "number"
    }
  ]
}
```
- `heatmap/graph/{username}/{dateString}` API는 날짜 별로 유저 활동 내역을 조회하는 API입니다.
- path variable인 dateString의 경우 date 형식의 값입니다. js의 Date 인스턴스를 그대로 넘겨주어도 되며, YYYY-MM-DD 와 같은 형식도 허용됩니다.
- YYYY-MM-DD 형식으로 보내는 경우 형식을 맞추어 보내야 됩니다. 월과 일이 한자릿수인 경우에 YYYY-M-D 이와 같은 형태로 호출하는 경우 기대한 응답이 아닐 수 있습니다. YYYY-MM-DD 형식을 지켜주세요.
- 해당 API를 호출한 유저와 path variable로 요청하는 username과 다른 경우 응답 구조의 diaries의 데이터들은 isPublic이 ture인 값들만 담아 반환합니다.
    - diaryCount의 경우 isPublic의 값과 상관없이 작성했던 일기의 개수로 응답합니다.
    - API를 호출한 유저와 path variable로 요청한 username이 같은 경우 diaries에 모든 데이터가 담겨 반환됩니다.(본인을 조회한 경우)
- 응답 데이터 구조는 아래와 같습니다.
```json
{
  "success": true,
  "data": {
    "date": "date",
    "activityCount": "number",
    "activities": {
      "diaries": [
        {
          "id": "uuid",
          "title": "string",
          "content": "text",
          "imgUrl": "null | string",
          "isPublic": "boolean",
          "favoriteCount": "number",
          "commentCount": "number",
          "createdAt": "Date(string)",
          "updatedAt": "Date(string)"
        }
      ]
    },
    "diaryCount": "number",
    "commentCount": "number",
    "randomMatchingCount": "number"
  }
}
```

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/4a8678a6-75af-4f19-b199-08e8741f2def)
![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/1c617ff6-aa61-4813-a89d-7c2f487491a5)


<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
