### PR TITLE
유저 정보 수정 API 개발

### DIFF
--- a/src/users/dto/user.dto.ts
+++ b/src/users/dto/user.dto.ts
@@ -1,4 +1,9 @@
-import { OmitType } from '@nestjs/swagger';
+import { OmitType, PickType } from '@nestjs/swagger';
 import { UserEntity } from '../users.entity';
 
 export class UserDTO extends OmitType(UserEntity, ['password'] as const) {}
+
+export class UserUpdateDTO extends PickType(UserEntity, [
+  'username',
+  'imgUrl',
+] as const) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -4,8 +4,10 @@ import {
   Get,
   Param,
   Post,
+  Put,
   UploadedFile,
   UseFilters,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -29,6 +31,9 @@ import {
 } from './dto/user-register.dto';
 import { UserLoginDTO } from './dto/user-login.dto';
 import { UsersService } from './users.service';
+import { UserDTO, UserUpdateDTO } from './dto/user.dto';
+import { JwtAuthGuard } from './jwt/jwt.guard';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 
 @ApiTags('USER')
 @Controller('users')
@@ -113,5 +118,14 @@ export class UsersController {
   @ApiResponse(responseExampleForUser.login)
   login(@Body() userLoginDto: UserLoginDTO) {
     return this.usersService.login(userLoginDto);
+  }
+
+  @Put()
+  @UseGuards(JwtAuthGuard)
+  updateUserInfo(
+    @CurrentUser() accessedUser: UserDTO,
+    @Body() userUpdateDto: UserUpdateDTO,
+  ) {
+    return this.usersService.updateUserInfo(accessedUser, userUpdateDto);
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -121,6 +121,12 @@ export class UsersController {
   }
 
   @Put()
+  @ApiOperation({
+    summary: '유저 정보 수정 API',
+    description:
+      'username, imgUrl field만 수정 가능, username의 경우 backend에서도 중복 여부 체크, 둘 중에 한 개의 값만 수정하고 싶은 경우에도 두 개의 값을 보내주어야함(바뀌지 않는 값은 기존에 있던 값으로 요청)',
+  })
+  @ApiResponse(responseExampleForUser.getUserInfo)
   @UseGuards(JwtAuthGuard)
   updateUserInfo(
     @CurrentUser() accessedUser: UserDTO,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -15,6 +15,7 @@ import { JwtService } from '@nestjs/jwt';
 import { userExceptionMessage } from 'src/constants/exceptionMessage';
 import { AwsService } from 'src/aws.service';
 import { UserToTermsAgreementsService } from 'src/user-to-terms-agreements/user-to-terms-agreements.service';
+import { UserDTO, UserUpdateDTO } from './dto/user.dto';
 
 @Injectable()
 export class UsersService {
@@ -157,5 +158,11 @@ export class UsersService {
     await this.usersRepository.save(adminUser);
 
     return adminUser;
+  }
+
+  async updateUserInfo(accessedUser: UserDTO, userUpdateDto: UserUpdateDTO) {
+    await this.usernameExists(userUpdateDto.username);
+    await this.usersRepository.update(accessedUser.id, userUpdateDto);
+    return await this.findUserById(accessedUser.id);
   }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #issue_number

<br />

## 🗒 작업 목록

- [x] 유저 정보 수정 API 개발
    - [x] 유저 정보 수정 DTO 생성
    - [x] swagger 적용


<br />

## 🧐 PR Point

- 유저 정보 수정 API
    - thumbnail image 변경
    - 닉네임 변경
- 위의 두개의 값을 받는 PUT method API 개발
- 뱃지 Pinned의 경우 아래의 Patch method API 사용
![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/65f172c9-3aec-4b7b-a4c5-4f610bbe2d8e)
- username, imgUrl field만 수정 가능
- username의 경우 backend에서도 중복 여부 체크
- 둘 중에 한 개의 값만 수정하고 싶은 경우에도 두 개의 값으로 요청(바뀌지 않는 값은 기존에 있던 값으로 요청)

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

![image](https://github.com/a-daily-diary/ADD.BE/assets/77317312/c4a3c02d-dbe9-45c5-9903-cd9b64d3ebc3)

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
