### PR TITLE
🩹 #67 - 이미지 저장 이름 변경

### DIFF
--- a/src/aws.service.ts
+++ b/src/aws.service.ts
@@ -26,9 +26,7 @@ export class AwsService {
     contentType: string;
   }> {
     try {
-      const key = `${folder}/${Date.now()}_${path.basename(
-        file.originalname,
-      )}`.replace(/ /g, '');
+      const key = `${folder}/${Date.now()}`.replace(/ /g, '');
 
       const s3Object = await this.awsS3
         .putObject({


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #issue_number

<br />

## 🗒 작업 목록

- [x] 사용자에게 받은 이미지명 변경 로직 추가

<br />

## 🧐 PR Point

- 이미지 업로드 API 사용 시 업로드한 파일의 이름을 사용하고 S3에 저장하도록 구현하였습니다.
- 위와 같이 구현하는 경우 영어가 아닌 한글로 된 파일 업로드 시 이름이 깨질 것으로 예상됨.
- default 이미지와 구분이 안됨 (default라는 키워드로 default 이미지를 구분하고 싶은 경우 문제가 발생)
- s3에 이미지가 저장되는 이름 변경
    - 기존 : 현재 시간 + 업로드한 파일 이름
    - 변경 : 현재 시간

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
