### PR TITLE
잔디 그래프 API 수정 사항 반영

### DIFF
--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -57,4 +57,5 @@ export const exceptionMessage = {
 
 export const heatmapExceptionMessage = {
   ONLY_DATE_TYPE: 'Date 타입 포맷의 요청만 가능합니다.',
+  ONLY_YEAR_FORMAT: '연도 포맷의 요청만 가능합니다.',
 };

--- a/src/heatmap/heatmap.controller.ts
+++ b/src/heatmap/heatmap.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Query,
   UseFilters,
   UseGuards,
 } from '@nestjs/common';
@@ -34,8 +35,14 @@ export class HeatmapController {
   @ApiBearerAuth('access-token')
   @ApiResponse(responseExampleForHeatmap.graphData)
   @UseGuards(JwtAuthGuard)
-  getHeatmapGraph(@Param('username') username: string) {
-    return this.heatmapService.getHeatmapGraphData(username);
+  getHeatmapGraph(
+    @Param('username') username: string,
+    @Query('year') year: `${number}`,
+  ) {
+    if (/^([0-9]){4}$/g.test(year) === false)
+      throw new BadRequestException(heatmapExceptionMessage.ONLY_YEAR_FORMAT);
+
+    return this.heatmapService.getHeatmapGraphData(username, year);
   }
 
   @Get('/graph/:username/:dateString')

--- a/src/heatmap/heatmap.controller.ts
+++ b/src/heatmap/heatmap.controller.ts
@@ -31,6 +31,7 @@ export class HeatmapController {
   @Get('/graph/:username')
   @ApiOperation({
     summary: '잔디 그래프 데이터용 API',
+    description: '잔디 그래프 데이터는 연도별로 제공됩니다.',
   })
   @ApiBearerAuth('access-token')
   @ApiResponse(responseExampleForHeatmap.graphData)

--- a/src/heatmap/heatmap.service.ts
+++ b/src/heatmap/heatmap.service.ts
@@ -56,7 +56,7 @@ export class HeatmapService {
         : 0;
 
       return {
-        date: new Date(dateString),
+        date: dateString,
         activityCount: diaryCount + commentCount,
       };
     });

--- a/src/utility/date.ts
+++ b/src/utility/date.ts
@@ -11,6 +11,7 @@ export const convertDateToString = (date: Date) => {
   return `${year}-${paddingMonth}-${paddingDay}`;
 };
 
+// deprecated
 export const generateLastOneYearDateList = () => {
   const toDate = new Date();
 
@@ -21,4 +22,21 @@ export const generateLastOneYearDateList = () => {
   });
 
   return lastOneYearDateList;
+};
+
+export const generateYearDateList = (targetYear: `${number}`) => {
+  const targetDate = new Date(`${targetYear}-01-01`);
+
+  const result = Array.from({ length: 365 }, (_, index) => {
+    const data = new Date(targetDate);
+    data.setDate(targetDate.getDate() + index);
+    return convertDateToString(data);
+  });
+
+  // 윤달인 경우 처리
+  if (result.at(-1) === `${targetYear}-12-30`) {
+    result.push(`${targetYear}-12-31`);
+  }
+
+  return result;
 };


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #103 

<br />

## 🗒 작업 목록

- [x] 연도별 잔디 그래프 api 조회 로직 추가
- [x] 요청 시 year 값이 숫자 4자리가 아닌 경우 예외처리 로직 추가
- [x] swagger 설명 추가

<br />

## 🧐 PR Point

- 어떤 이유로 코드를 변경했나요?
- 리뷰어가 집중해야하는 포인트가 어디인가요?
- 해당 작업에서 주의 해야할 부분이 있나요?
- 반환되는 date 값 형식 변경
    - 기존 : "2024-03-09T00:00:00.000Z"
    - 변경 : "2024-03-09"
    - 시간까지의 값은 필요하지 않다고 생각했으며, 변경된 값으로도 new Date()의 인수로 사용할 수 있다고 판단하여 이와 같이 변경하였습니다.
<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

<img width="765" alt="image" src="https://github.com/a-daily-diary/ADD.BE/assets/77317312/3d1d2fad-b30d-4105-b6b7-db37f368f8a9">

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
