### PR TITLE
뱃지 Pinned API 500 에러 처리

### DIFF
--- a/src/user-to-badges/user-to-badges.service.ts
+++ b/src/user-to-badges/user-to-badges.service.ts
@@ -76,11 +76,6 @@ export class UserToBadgesService {
         userToBadgesExceptionMessage.DOES_NOT_EXIST_USER_TO_BADGE,
       );
 
-    if (targetUserToBadge.user.id !== accessedUser.id)
-      throw new BadRequestException(
-        userToBadgesExceptionMessage.OWNER_ONLY_PINNED,
-      );
-
     const pinnedCount = await this.userToBadgeRepository
       .createQueryBuilder('userToBadge')
       .leftJoin('userToBadge.user', 'user')


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #111

<br />

## 🗒 작업 목록

- [x] DB에서 조회한 뱃지 데이터의 유저와 API를 요청한 유저를 비교하는 예외 처리 로직 제거

<br />

## 🧐 PR Point

- 접근한 유저에 대해 DB에서 조회를 했으므로, 이후 로직에서 API 요청한 유저에 대한 예외처리는 필요없는 로직으로 판단하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
