### PR TITLE
Badge Update API 개별 속성 수정으로 변경

### DIFF
--- a/src/badges/badges.controller.ts
+++ b/src/badges/badges.controller.ts
@@ -37,6 +37,7 @@ import { UserDTO } from 'src/users/dto/user.dto';
 import { BadgeFormDTO } from './dto/badge-form.dto';
 import { BadgeCode } from 'src/types/badges.type';
 import { UserToBadgesService } from 'src/user-to-badges/user-to-badges.service';
+import { BadgeUpdateFormDTO } from './dto/badge-update-form.dto';
 
 @ApiTags('Badge')
 @Controller('badges')
@@ -144,9 +145,9 @@ export class BadgesController {
   @UseGuards(JwtAuthGuard)
   updateBadge(
     @Param('badgeId', new ParseEnumPipe(BadgeCode)) badgeId: BadgeCode,
-    @Body() badgeFormDTO: BadgeFormDTO,
+    @Body() badgeUpdateFormDTO: BadgeUpdateFormDTO,
   ) {
-    return this.badgesService.updateBadge(badgeId, badgeFormDTO);
+    return this.badgesService.updateBadge(badgeId, badgeUpdateFormDTO);
   }
 
   @Delete(':badgeId')

--- a/src/badges/badges.entity.ts
+++ b/src/badges/badges.entity.ts
@@ -27,7 +27,7 @@ export class BadgeEntity {
   @ApiProperty()
   @IsString()
   @IsNotEmpty({ message: '뱃지의 이름을 설정해주세요.' })
-  @Column({ type: 'varchar', nullable: false })
+  @Column({ type: 'varchar', nullable: false, unique: true })
   name: string;
 
   @ApiProperty()

--- a/src/badges/badges.service.ts
+++ b/src/badges/badges.service.ts
@@ -25,6 +25,7 @@ import {
   steady2Badge,
   steady3Badge,
 } from 'src/data/badges';
+import { BadgeUpdateFormDTO } from './dto/badge-update-form.dto';
 
 @Injectable()
 export class BadgesService {
@@ -127,21 +128,24 @@ export class BadgesService {
     return newBadgeList;
   }
 
-  async updateBadge(badgeId: BadgeCode, badgeFormDTO: BadgeFormDTO) {
+  async updateBadge(
+    badgeId: BadgeCode,
+    badgeUpdateFormDTO: BadgeUpdateFormDTO,
+  ) {
     const targetBadge = await this.findById(badgeId);
 
     if (!targetBadge) {
       throw new NotFoundException(badgeExceptionMessage.DOES_NOT_EXIST_BADGE);
     }
 
-    const hasBadgeName = await this.findByBadgeName(badgeFormDTO.name);
+    const badgeByName = await this.findByBadgeName(badgeUpdateFormDTO.name);
 
-    if (hasBadgeName) {
+    if (badgeByName && targetBadge.id !== badgeByName.id) {
       throw new BadRequestException(badgeExceptionMessage.EXIST_BADGE_NAME);
     }
 
-    // FIXME: 접근한 유저가 관리자인기 확인 로직 추가 예정
-    await this.badgeRepository.update(badgeId, badgeFormDTO);
+    // FIXME: 접근한 유저가 관리자인지 확인 로직 추가 예정
+    await this.badgeRepository.update(badgeId, badgeUpdateFormDTO);
 
     return await this.findById(badgeId);
   }

--- a/src/badges/dto/badge-update-form.dto.ts
+++ b/src/badges/dto/badge-update-form.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType, PickType } from '@nestjs/swagger';
+import { BadgeEntity } from '../badges.entity';
+
+export class BadgeUpdateFormDTO extends PartialType(
+  PickType(BadgeEntity, ['name', 'description', 'imgUrl'] as const),
+) {}


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #113

<br />

## 🗒 작업 목록

- [x] Badge name unique 값 설정
- [x] Badge Update Form DTO 추가
- [x] API 요청 시 원하는 값만 수정할 수 있도록 변경

<br />

## 🧐 PR Point

- 기존에는 뱃지 수정 시 badge form DTO를 사용하였습니다.
- 위와 같은 이유로 update 요청 시 badge form에 대한 모든 필드를 넣어야 제대로 요청이 가는 문제가 발생하였습니다.
- 해당 이슈를 해결하기 위해 Nest의 PartialType을 사용하여 필수값이 아닌 Badge Form DTO를 다시 정의하여 원하는 필드만 요청할 수 있도록 수정할 예정입니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
