### PR TITLE
Badge 데이터셋 이미지 경로 수정

### DIFF
--- a/src/data/badges.ts
+++ b/src/data/badges.ts
@@ -32,27 +32,27 @@ export const steady3Badge: BadgeFormDTO = {
 export const newBieBadge: BadgeFormDTO = {
   id: BadgeCode.new_bie,
   name: '디디의 첫걸음',
-  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/steady/new_bie.png',
+  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/activity/new_bie.png',
   description: '기본 thumbnail 변경',
 };
 
 export const bookmarkBadge: BadgeFormDTO = {
   id: BadgeCode.bookmark,
   name: '일기 수집가',
-  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/steady/bookmark.png',
+  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/activity/bookmark.png',
   description: '북마크 10회 등록',
 };
 
 export const heartBadge: BadgeFormDTO = {
   id: BadgeCode.heart,
   name: '응원의 하트',
-  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/steady/heart.png',
+  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/activity/heart.png',
   description: '하트 10회 등록',
 };
 
 export const commentBadge: BadgeFormDTO = {
   id: BadgeCode.comment,
   name: '리액션 부자',
-  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/steady/comment.png',
+  imgUrl: 'http://add.bucket.s3.amazonaws.com/badges/activity/comment.png',
   description: '댓글 10회 작성',
 };


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #114

<br />

## 🗒 작업 목록

- [x] 활동 관련 뱃지 이미지 경로 변경

<br />

## 🧐 PR Point

- 현재 모든 뱃지에 대한 경로를 steady(꾸준함)로 설정되어 있습니다.
- 위와 같은 이유로 activity(활동) 뱃지의 경우 조회가 되지 않는 이슈가 발생하였습니다.
- 해당 이슈를 통해 잘못설정되어 있는 데이터를 수정할 예정입니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
