### PR TITLE
비밀번호 재설정 API validation 버그 fix

### DIFF
--- a/src/users/dto/password-reset.dto.ts
+++ b/src/users/dto/password-reset.dto.ts
@@ -1,13 +1,16 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { Column } from 'typeorm';
 import { UserEntity } from '../users.entity';
-import { IsNotEmpty, IsString } from 'class-validator';
 
-export class PasswordResetDTO extends PickType(UserEntity, [
-  'email',
-  'tempToken',
-] as const) {
+export class PasswordResetDTO extends PickType(UserEntity, ['email'] as const) {
   @ApiProperty()
   @IsString()
   @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
   password: string;
+
+  @ApiProperty()
+  @IsUUID()
+  @Column({ type: 'uuid', nullable: true, default: null })
+  tempToken: string | null;
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #119

<br />

## 🗒 작업 목록

- [x] reset password dto 구성 변경

<br />

## 🧐 PR Point

- user entity의 exclude 데코레이터 사용 시 상속 받은 클래스에서도 제외되는 이슈가 발생하였습니다.
- 위와 같은 이슈로 상속 받은 클래스에 이미 정의되어 있는 컬럼일지라도 별도의 설정이 필요한 경우 다시 선언하여 사용하는 방식으로 해당 이슈를 처리하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
