### PR TITLE
유저에게 발급된 임시 토큰(비밀번호 재설정을 위한 토큰)이 유효한지 체크하는 API 개발

### DIFF
--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -88,6 +88,9 @@ export const responseExampleForUser = {
   passwordReset: responseTemplate({
     message: '비밀번호가 재설정되었습니다.',
   }),
+  tempTokenValidation: responseTemplate({
+    isValidate: 'boolean',
+  }),
   login: responseTemplate({
     token: 'token',
     user: userResponse,

--- a/src/users/dto/password-reset.dto.ts
+++ b/src/users/dto/password-reset.dto.ts
@@ -11,6 +11,7 @@ export class PasswordResetDTO extends PickType(UserEntity, ['email'] as const) {
 
   @ApiProperty()
   @IsUUID()
-  @Column({ type: 'uuid', nullable: true, default: null })
-  tempToken: string | null;
+  @IsNotEmpty({ message: '임시 토큰을 입력해주세요.' })
+  @Column({ type: 'uuid' })
+  tempToken: string;
 }

--- a/src/users/dto/temp-token-validation.dto.ts
+++ b/src/users/dto/temp-token-validation.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID } from 'class-validator';
+import { Column } from 'typeorm';
+import { UserEntity } from '../users.entity';
+
+export class TempTokenValidationDTO extends PickType(UserEntity, [
+  'email',
+] as const) {
+  @ApiProperty()
+  @IsUUID()
+  @IsNotEmpty({ message: '임시 토큰을 입력해주세요.' })
+  @Column({ type: 'uuid' })
+  tempToken: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -36,6 +36,7 @@ import { JwtAuthGuard } from './jwt/jwt.guard';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { PasswordResetLinkDTO } from './dto/password-reset-link.dto';
 import { PasswordResetDTO } from './dto/password-reset.dto';
+import { TempTokenValidationDTO } from './dto/temp-token-validation.dto';
 
 @ApiTags('USER')
 @Controller('users')
@@ -139,6 +140,16 @@ export class UsersController {
     @Body() sendPasswordResetLinkDTO: PasswordResetLinkDTO,
   ) {
     return this.usersService.sendPasswordResetLink(sendPasswordResetLinkDTO);
+  }
+
+  @Post('temp-token-validation')
+  @ApiOperation({
+    summary: '이메일과 임시 토큰이 유효한지 여부를 반환하는 API',
+    description:
+      '이메일과 임시 토큰을 body로 요청하면, 유효여부를 boolean 값으로 반환합니다.',
+  })
+  tempTokenValidation(@Body() tempTokenValidationDTO: TempTokenValidationDTO) {
+    return this.usersService.tempTokenValidation(tempTokenValidationDTO);
   }
 
   @Put('password')

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -148,6 +148,7 @@ export class UsersController {
     description:
       '이메일과 임시 토큰을 body로 요청하면, 유효여부를 boolean 값으로 반환합니다.',
   })
+  @ApiResponse(responseExampleForUser.tempTokenValidation)
   tempTokenValidation(@Body() tempTokenValidationDTO: TempTokenValidationDTO) {
     return this.usersService.tempTokenValidation(tempTokenValidationDTO);
   }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -20,6 +20,7 @@ import { UserDTO, UserUpdateDTO } from './dto/user.dto';
 import { PasswordResetLinkDTO } from './dto/password-reset-link.dto';
 import { MailService } from 'src/email.service';
 import { PasswordResetDTO } from './dto/password-reset.dto';
+import { TempTokenValidationDTO } from './dto/temp-token-validation.dto';
 
 @Injectable()
 export class UsersService {
@@ -137,6 +138,14 @@ ${redirectUrl}?email=${email}&token=${user.tempToken}`,
     }, 1000 * 60 * 5); // 5 minutes
 
     return { message: '비밀번호 재설정 메일이 발송되었습니다.' };
+  }
+
+  async tempTokenValidation(tempTokenValidation: TempTokenValidationDTO) {
+    const { email, tempToken } = tempTokenValidation;
+
+    const user = await this.findUserByEmail(email);
+
+    return { isValidate: user.tempToken === tempToken };
   }
 
   async passwordReset(passwordResetDTO: PasswordResetDTO) {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #121

<br />

## 🗒 작업 목록

- [x] 이메일과 임시 토큰 유효 여부 반환 API 개발
- [x] swagger 갱신

<br />

## 🧐 PR Point

- 프론트에서 비밀번호 재설정 페이지 접근 시 접근한 유저와 임시 토큰이 유효하지 않은 경우 페이지 접근 제한 기능 추가
- 접근 유저의 이메일과 임시 토큰이 유효한지 여부를 반환하는 API 개발

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

<img width="1246" alt="image" src="https://github.com/a-daily-diary/ADD.BE/assets/77317312/f8a61613-4f83-4572-a07c-256729ea14e7">

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
