### PR TITLE
사용자 정보 수정 API 이슈 (프로필 사진만 변경하는 경우 중복 닉네임 예외 처리)

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -17,6 +17,7 @@ import {
   ApiResponse,
   ApiOperation,
   ApiTags,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { FileUploadDto } from 'src/common/dto/FileUpload.dto';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
@@ -170,6 +171,7 @@ export class UsersController {
   })
   @ApiResponse(responseExampleForUser.getUserInfo)
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
   updateUserInfo(
     @CurrentUser() accessedUser: UserDTO,
     @Body() userUpdateDto: UserUpdateDTO,

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -167,7 +167,7 @@ export class UsersController {
   @ApiOperation({
     summary: '유저 정보 수정 API',
     description:
-      'username, imgUrl field만 수정 가능, username의 경우 backend에서도 중복 여부 체크, 둘 중에 한 개의 값만 수정하고 싶은 경우에도 두 개의 값을 보내주어야함(바뀌지 않는 값은 기존에 있던 값으로 요청)',
+      'username, imgUrl field만 수정 가능, username의 경우 중복 여부 체크, 둘 중에 한 개의 값만 수정하고 싶은 경우에도 두 개의 값을 보내주어야함(바뀌지 않는 값은 기존에 있던 값으로 요청)',
   })
   @ApiResponse(responseExampleForUser.getUserInfo)
   @UseGuards(JwtAuthGuard)

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -228,7 +228,10 @@ ${redirectUrl}?email=${email}&token=${user.tempToken}`,
   }
 
   async updateUserInfo(accessedUser: UserDTO, userUpdateDto: UserUpdateDTO) {
-    await this.usernameExists(userUpdateDto.username);
+    if (accessedUser.username !== userUpdateDto.username) {
+      await this.usernameExists(userUpdateDto.username);
+    }
+
     await this.usersRepository.update(accessedUser.id, userUpdateDto);
     return await this.findUserById(accessedUser.id);
   }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #124 

<br />

## 🗒 작업 목록

- [x] 사용자 정보 수정 API 요청 시 본인인 경우 닉네임 중복 허용 로직 추가
- [x] 사용자 정보 수정 API swagger token 설정

<br />

## 🧐 PR Point

- Api 요청한 사용자와 수정 값의 닉네임이 다른 경우만 닉네임 중복 검사

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [ ] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [ ] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [ ] 불필요한 `console`이 존재하지 않습니다.
