### PR TITLE
비밀번호 재설정 API 수정 (로그인한 유저의 경우 처리)

### DIFF
--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -18,7 +18,8 @@ export const userExceptionMessage = {
   INCORRECT_LOGIN: '로그인 정보를 확인해주세요.',
   DOES_NOT_EXIST_USER: '해당하는 유저가 존재하지 않습니다.',
   UNAUTHORIZED: '로그인이 필요합니다.',
-  INVALID_TOKEN: '토큰이 일치하지 않습니다.',
+  INVALID_TOKEN: '유효하지 않은 토큰입니다.',
+  INVALID_JWT_TOKEN: '변경하려는 이메일과 토큰 정보가 일치하지 않습니다.',
 };
 
 export const bookmarkExceptionMessage = {

--- a/src/users/dto/password-reset.dto.ts
+++ b/src/users/dto/password-reset.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { Column } from 'typeorm';
 import { UserEntity } from '../users.entity';
 
@@ -10,8 +10,7 @@ export class PasswordResetDTO extends PickType(UserEntity, ['email'] as const) {
   password: string;
 
   @ApiProperty()
-  @IsUUID()
-  @IsNotEmpty({ message: '임시 토큰을 입력해주세요.' })
+  @IsNotEmpty({ message: '토큰을 입력해주세요.' })
   @Column({ type: 'uuid' })
-  tempToken: string;
+  token: string;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -157,6 +157,8 @@ export class UsersController {
   @Put('password')
   @ApiOperation({
     summary: '비밀번호 재설정 API',
+    description:
+      'Request Body에 token 값은 이메일로 받은 임시 토큰 혹은 유효한 jwt 토큰을 입력해야 합니다.',
   })
   @ApiResponse(responseExampleForUser.passwordReset)
   passwordReset(@Body() passwordResetDTO: PasswordResetDTO) {


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #127
<br />

## 🗒 작업 목록

- [x] 비밀번호 재설정 request DTO 수정
- [x] request DTO의 토큰 값이 유효한 JWT 토큰이며, 전달되는 이메일과 토큰의 이메일이 동일한 경우 비밀번호가 재설정되도록 처리
- [x] swagger 갱신

## 🧐 PR Point

- 기존의 비밀번호 재설정 API에선 Request Body의 Key 중 tempToken(임시토큰)이 존재했습니다.
    - 해당 PR을 통해 로그인을 한 경우 비밀번호 재설정 API 사용 시, 임시 토큰을 사용하는 것 대신 유효한 JWT 토큰을 사용할 수 있도록 변경하였습니다.
    - 위와 같은 이유로 Request Body의 tempToken이라는 Key 값을 token으로 변경하여, *임시 토큰*, *JWT 토큰*을 담을 수 있도록 naming을 확장하였습니다.
- **비밀번호 재설정 API 사용법**은 다음과 같습니다.
1. 비로그인 시 : 임시 토큰 발급을 위한 메일 전송 API 사용 후 발급 받은 임시 토큰을 Request Body의 token 값에 넣어 요청한다.
2. 로그인 시    : 로그인 시 발급 받은 JWT 토큰을 Requset Body의 token 값에 넣어 요청한다.

\* 예외 처리: JWT 토큰을 사용하는 경우 **토큰의 계정 email**과 **비밀번호 재설정 API의 Body에 있는 email**이 동일하지 않은 경우 요청에 실패합니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/30637aeb-81d8-404b-9f30-0326a2c0bbea">

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
