### PR TITLE
매칭 이력 API 개발

### DIFF
--- a/src/activities/activities.module.ts
+++ b/src/activities/activities.module.ts
@@ -4,9 +4,16 @@ import { ActivitiesController } from './activities.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DiaryEntity } from 'src/diaries/diaries.entity';
 import { CommentEntity } from 'src/comments/comments.entity';
+import { MatchingHistoryEntity } from 'src/matching-histories/matching-histories.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DiaryEntity, CommentEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      DiaryEntity,
+      CommentEntity,
+      MatchingHistoryEntity,
+    ]),
+  ],
   providers: [ActivitiesService],
   controllers: [ActivitiesController],
   exports: [ActivitiesService],

--- a/src/activities/activities.service.ts
+++ b/src/activities/activities.service.ts
@@ -139,9 +139,18 @@ export class ActivitiesService {
       })
       .getCount();
 
+    const randomMatchingCount = await this.matchingHistoryRepository
+      .createQueryBuilder('matchingHistory')
+      .leftJoin('matchingHistory.user', 'user')
+      .where('user.username = :username', { username })
+      .andWhere("to_char(matchingHistory.createdAt, 'YYYY-MM-DD') = :date", {
+        date: convertDateToString(date),
+      })
+      .getCount();
+
     return {
       date,
-      activityCount: diaryCount + commentCount,
+      activityCount: diaryCount + commentCount + randomMatchingCount,
       activities: {
         diaries: resultDiaries.filter(
           (diary) =>
@@ -149,7 +158,7 @@ export class ActivitiesService {
         ),
         diaryCount,
         commentCount,
-        randomMatchingCount: 0,
+        randomMatchingCount,
       },
     };
   }

--- a/src/activities/activities.service.ts
+++ b/src/activities/activities.service.ts
@@ -10,6 +10,7 @@ import {
   generateLastOneYearDateList,
   generateYearDateList,
 } from 'src/utility/date';
+import { MatchingHistoryEntity } from 'src/matching-histories/matching-histories.entity';
 
 @Injectable()
 export class ActivitiesService {
@@ -18,6 +19,8 @@ export class ActivitiesService {
     private readonly diariesRepository: Repository<DiaryEntity>,
     @InjectRepository(CommentEntity)
     private readonly commentsRepository: Repository<CommentEntity>,
+    @InjectRepository(MatchingHistoryEntity)
+    private readonly matchingHistoryRepository: Repository<MatchingHistoryEntity>,
   ) {}
   async getHeatmapGraphData(username: string, year?: `${number}`) {
     const diariesCountQuery = this.diariesRepository
@@ -34,6 +37,13 @@ export class ActivitiesService {
       .addSelect('COUNT(*)', 'commentCount')
       .where('commenter.username = :username', { username });
 
+    const matchingHistoryCountQuery = this.matchingHistoryRepository
+      .createQueryBuilder('matchingHistory')
+      .leftJoin('matchingHistory.user', 'user')
+      .select("DATE_TRUNC('day', matchingHistory.createdAt) as date")
+      .addSelect('COUNT(*)', 'matchingHistoryCount')
+      .where('user.username = :username', { username });
+
     if (year !== undefined) {
       diariesCountQuery.andWhere(
         `EXTRACT(YEAR FROM diary.createdAt) = :yearToQuery`,
@@ -48,6 +58,13 @@ export class ActivitiesService {
           yearToQuery: year,
         },
       );
+
+      matchingHistoryCountQuery.andWhere(
+        `EXTRACT(YEAR FROM matchingHistory.createdAt) = :yearToQuery`,
+        {
+          yearToQuery: year,
+        },
+      );
     }
     const diaryCountGroupByDate = await diariesCountQuery
       .groupBy("DATE_TRUNC('day', diary.createdAt)")
@@ -55,6 +72,10 @@ export class ActivitiesService {
 
     const commentCountGroupByDate = await commentsCountQuery
       .groupBy("DATE_TRUNC('day', comment.createdAt)")
+      .getRawMany();
+
+    const matchingHistoryCountGroupByDate = await matchingHistoryCountQuery
+      .groupBy("DATE_TRUNC('day', matchingHistory.createdAt)")
       .getRawMany();
 
     const yearDateList =
@@ -69,15 +90,22 @@ export class ActivitiesService {
       const commentCountInfo = commentCountGroupByDate.find(
         (el) => convertDateToString(el.date) === dateString,
       );
+      const matchingHistoryCountInfo = matchingHistoryCountGroupByDate.find(
+        (el) => convertDateToString(el.date) === dateString,
+      );
 
       const diaryCount = diaryCountInfo ? +diaryCountInfo.diaryCount : 0;
       const commentCount = commentCountInfo
         ? +commentCountInfo.commentCount
         : 0;
 
+      const matchingHistoryCount = matchingHistoryCountInfo
+        ? +matchingHistoryCountInfo.matchingHistoryCount
+        : 0;
+
       return {
         date: dateString,
-        activityCount: diaryCount + commentCount,
+        activityCount: diaryCount + commentCount + matchingHistoryCount,
       };
     });
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { MailService } from './email.service';
 import { MatchingRulesModule } from './matching-rules/matching-rules.module';
 import { ActivitiesModule } from './activities/activities.module';
 import { MatchingModule } from './matching/matching.module';
+import { MatchingHistoriesModule } from './matching-histories/matching-histories.module';
 
 const typeOrmModuleOptions = {
   useFactory: async (): Promise<TypeOrmModuleOptions> => {
@@ -69,6 +70,7 @@ const typeOrmModuleOptions = {
     MatchingRulesModule,
     ActivitiesModule,
     MatchingModule,
+    MatchingHistoriesModule,
   ],
   controllers: [AppController],
   providers: [AppService, AwsService, MailService],

--- a/src/constants/exceptionMessage.ts
+++ b/src/constants/exceptionMessage.ts
@@ -61,3 +61,7 @@ export const ActivitiesExceptionMessage = {
   ONLY_DATE_TYPE: 'Date 타입 포맷의 요청만 가능합니다.',
   ONLY_YEAR_FORMAT: '연도 포맷의 요청만 가능합니다.',
 };
+
+export const matchingHistoryExceptionMessage = {
+  DOES_NOT_EXIST_MATCHING_HISTORY: '해당하는 매칭 이력은 존재하지 않습니다.',
+};

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -257,4 +257,13 @@ export const responseExampleForMatchingHistory = {
     matchedUser: userResponse,
     createdAt: 'date',
   }),
+  getMatchingHistories: responseTemplate([
+    {
+      id: 'uuid',
+      matchTime: 'number',
+      user: userResponse,
+      matchedUser: userResponse,
+      createdAt: 'date',
+    },
+  ]),
 };

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -248,3 +248,13 @@ export const responseExampleForActivities = {
     randomMatchingCount: 'number',
   }),
 };
+
+export const responseExampleForMatchingHistory = {
+  createMatchingHistory: responseTemplate({
+    id: 'uuid',
+    matchTime: 'number',
+    user: userResponse,
+    matchedUser: userResponse,
+    createdAt: 'date',
+  }),
+};

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -266,4 +266,5 @@ export const responseExampleForMatchingHistory = {
       createdAt: 'date',
     },
   ]),
+  deleteMatchingHistory: responseTemplate(deleteResponse),
 };

--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -6,10 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AwsService } from 'src/aws.service';
-import {
-  diaryExceptionMessage,
-  exceptionMessage,
-} from 'src/constants/exceptionMessage';
+import { diaryExceptionMessage } from 'src/constants/exceptionMessage';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { Brackets, Repository } from 'typeorm';
 import { DiaryEntity } from './diaries.entity';
@@ -207,7 +204,7 @@ export class DiariesService {
   }
 
   async create(diaryFormDto: DiaryFormDTO, author: UserDTO) {
-    const newDiary = await this.diaryRepository.create({
+    const newDiary = this.diaryRepository.create({
       author,
       ...diaryFormDto,
     });

--- a/src/matching-histories/dto/matching-history-form.dto.ts
+++ b/src/matching-histories/dto/matching-history-form.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { MatchingHistoryEntity } from '../matching-histories.entity';
+import { IsNotEmpty } from 'class-validator';
+
+export class MatchingHistoryFormDTO extends PickType(MatchingHistoryEntity, [
+  'matchTime',
+] as const) {
+  @ApiProperty()
+  @IsNotEmpty({ message: '매칭 상대의 아이디를 입력해주세요.' })
+  matchedUserId: string;
+}

--- a/src/matching-histories/matching-histories.controller.ts
+++ b/src/matching-histories/matching-histories.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Post, UseFilters, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/users/jwt/jwt.guard';
+import { MatchingHistoryFormDTO } from './dto/matching-history-form.dto';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { UserDTO } from 'src/users/dto/user.dto';
+import { MatchingHistoriesService } from './matching-histories.service';
+import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
+
+@Controller('matching-histories')
+@UseFilters(HttpApiExceptionFilter)
+export class MatchingHistoriesController {
+  constructor(
+    private readonly matchingHistoriesService: MatchingHistoriesService,
+  ) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  createMatchingHistory(
+    @Body() matchingHistoryForm: MatchingHistoryFormDTO,
+    @CurrentUser() currentUser: UserDTO,
+  ) {
+    return this.matchingHistoriesService.create(
+      matchingHistoryForm,
+      currentUser,
+    );
+  }
+}

--- a/src/matching-histories/matching-histories.controller.ts
+++ b/src/matching-histories/matching-histories.controller.ts
@@ -70,6 +70,10 @@ export class MatchingHistoriesController {
   }
 
   @Delete(':historyId')
+  @ApiOperation({
+    summary: '매칭 이력 삭제 (개발용)',
+  })
+  @ApiResponse(responseExampleForMatchingHistory.deleteMatchingHistory)
   deleteMatchingHistory(@Param('historyId', ParseUUIDPipe) historyId: string) {
     console.log(historyId);
     return this.matchingHistoriesService.delete(historyId);

--- a/src/matching-histories/matching-histories.controller.ts
+++ b/src/matching-histories/matching-histories.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Post, UseFilters, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from 'src/users/jwt/jwt.guard';
 import { MatchingHistoryFormDTO } from './dto/matching-history-form.dto';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
@@ -39,5 +46,11 @@ export class MatchingHistoriesController {
       matchingHistoryForm,
       currentUser,
     );
+  }
+
+  @Get()
+  // 개발용
+  getMatchingHistories() {
+    return this.matchingHistoriesService.getMatchingHistories();
   }
 }

--- a/src/matching-histories/matching-histories.controller.ts
+++ b/src/matching-histories/matching-histories.controller.ts
@@ -16,6 +16,7 @@ import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exception
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -50,6 +51,13 @@ export class MatchingHistoriesController {
   }
 
   @Get()
+  @ApiOperation({
+    summary: '매칭 이력 조회 (개발용)',
+    description: '매칭 이력 생성일을 기준을 내림차순 정렬(최신 먼저)합니다.',
+  })
+  @ApiQuery({ name: 'take', required: false, type: 'number' })
+  @ApiQuery({ name: 'skip', required: false, type: 'number' })
+  @ApiResponse(responseExampleForMatchingHistory.getMatchingHistories)
   // 개발용
   getMatchingHistories(
     @Query('take') take?: number | typeof NaN,

--- a/src/matching-histories/matching-histories.controller.ts
+++ b/src/matching-histories/matching-histories.controller.ts
@@ -1,7 +1,10 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
+  Param,
+  ParseUUIDPipe,
   Post,
   Query,
   UseFilters,
@@ -64,5 +67,11 @@ export class MatchingHistoriesController {
     @Query('skip') skip?: number | typeof NaN,
   ) {
     return this.matchingHistoriesService.getMatchingHistories(take, skip);
+  }
+
+  @Delete(':historyId')
+  deleteMatchingHistory(@Param('historyId', ParseUUIDPipe) historyId: string) {
+    console.log(historyId);
+    return this.matchingHistoriesService.delete(historyId);
   }
 }

--- a/src/matching-histories/matching-histories.controller.ts
+++ b/src/matching-histories/matching-histories.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Post,
+  Query,
   UseFilters,
   UseGuards,
 } from '@nestjs/common';
@@ -50,7 +51,10 @@ export class MatchingHistoriesController {
 
   @Get()
   // 개발용
-  getMatchingHistories() {
-    return this.matchingHistoriesService.getMatchingHistories();
+  getMatchingHistories(
+    @Query('take') take?: number | typeof NaN,
+    @Query('skip') skip?: number | typeof NaN,
+  ) {
+    return this.matchingHistoriesService.getMatchingHistories(take, skip);
   }
 }

--- a/src/matching-histories/matching-histories.controller.ts
+++ b/src/matching-histories/matching-histories.controller.ts
@@ -5,7 +5,15 @@ import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { MatchingHistoriesService } from './matching-histories.service';
 import { HttpApiExceptionFilter } from 'src/common/exceptions/http-api-exceptions.filter';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { responseExampleForMatchingHistory } from 'src/constants/swagger';
 
+@ApiTags('MatchingHistory')
 @Controller('matching-histories')
 @UseFilters(HttpApiExceptionFilter)
 export class MatchingHistoriesController {
@@ -14,6 +22,14 @@ export class MatchingHistoriesController {
   ) {}
 
   @Post()
+  @ApiOperation({
+    summary: '매칭 이력 생성',
+    description: `
+    matchTime의 단위는 초(seconds)입니다.
+    하나의 매칭이 종료되면 2개의 매칭 이력이 생성됩니다.(각자 이력 생성)`,
+  })
+  @ApiBearerAuth('access-token')
+  @ApiResponse(responseExampleForMatchingHistory.createMatchingHistory)
   @UseGuards(JwtAuthGuard)
   createMatchingHistory(
     @Body() matchingHistoryForm: MatchingHistoryFormDTO,

--- a/src/matching-histories/matching-histories.entity.ts
+++ b/src/matching-histories/matching-histories.entity.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsUUID } from 'class-validator';
+import { UserEntity } from 'src/users/users.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Index('matchingHistoryId', ['id'], { unique: true })
+@Entity({
+  name: 'MATCHING_HISTORY',
+})
+export class MatchingHistoryEntity {
+  @IsUUID()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty()
+  @ManyToOne(() => UserEntity, (user: UserEntity) => user.matchingHistories, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'user_id',
+    referencedColumnName: 'id',
+  })
+  user: UserEntity;
+
+  @ApiProperty()
+  @ManyToOne(() => UserEntity)
+  matchedUser: UserEntity;
+
+  @ApiProperty()
+  @IsNumber()
+  @IsNotEmpty({ message: '매칭 시간을 입력해주세요.' })
+  @Column({ type: 'numeric', nullable: false })
+  matchTime: number;
+
+  @CreateDateColumn({
+    type: 'timestamptz' /* timestamp with time zone */,
+  })
+  createdAt: Date;
+}

--- a/src/matching-histories/matching-histories.entity.ts
+++ b/src/matching-histories/matching-histories.entity.ts
@@ -1,9 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Exclude } from 'class-transformer';
 import { IsNotEmpty, IsNumber, IsUUID } from 'class-validator';
 import { UserEntity } from 'src/users/users.entity';
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   Index,
   JoinColumn,
@@ -44,4 +46,9 @@ export class MatchingHistoryEntity {
     type: 'timestamptz' /* timestamp with time zone */,
   })
   createdAt: Date;
+
+  // Soft Delete : 기존에는 null, 삭제 시 timestamp를 찍는다.
+  @Exclude()
+  @DeleteDateColumn({ type: 'timestamptz' })
+  deleteAt?: Date | null;
 }

--- a/src/matching-histories/matching-histories.module.ts
+++ b/src/matching-histories/matching-histories.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MatchingHistoryEntity } from './matching-histories.entity';
+import { MatchingHistoriesController } from './matching-histories.controller';
+import { MatchingHistoriesService } from './matching-histories.service';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MatchingHistoryEntity])],
+  imports: [TypeOrmModule.forFeature([MatchingHistoryEntity]), UsersModule],
+  controllers: [MatchingHistoriesController],
+  providers: [MatchingHistoriesService],
+  exports: [MatchingHistoriesService],
 })
 export class MatchingHistoriesModule {}

--- a/src/matching-histories/matching-histories.module.ts
+++ b/src/matching-histories/matching-histories.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MatchingHistoryEntity } from './matching-histories.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MatchingHistoryEntity])],
+})
+export class MatchingHistoriesModule {}

--- a/src/matching-histories/matching-histories.service.ts
+++ b/src/matching-histories/matching-histories.service.ts
@@ -32,4 +32,14 @@ export class MatchingHistoriesService {
 
     return newMatchingHistory;
   }
+
+  async getMatchingHistories() {
+    const matchingHistories = await this.matchingHistoryRepository
+      .createQueryBuilder('matchingHistory')
+      .leftJoinAndSelect('matchingHistory.user', 'user')
+      .leftJoinAndSelect('matchingHistory.matchedUser', 'matchedUser')
+      .getMany();
+
+    return matchingHistories;
+  }
 }

--- a/src/matching-histories/matching-histories.service.ts
+++ b/src/matching-histories/matching-histories.service.ts
@@ -5,6 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { MatchingHistoryEntity } from './matching-histories.entity';
 import { Repository } from 'typeorm';
 import { UsersService } from 'src/users/users.service';
+import { DEFAULT_SKIP, DEFAULT_TAKE } from 'src/constants/page';
 
 @Injectable()
 export class MatchingHistoriesService {
@@ -33,12 +34,15 @@ export class MatchingHistoriesService {
     return newMatchingHistory;
   }
 
-  async getMatchingHistories() {
+  async getMatchingHistories(take = DEFAULT_TAKE, skip = DEFAULT_SKIP) {
     const matchingHistories = await this.matchingHistoryRepository
       .createQueryBuilder('matchingHistory')
       .leftJoinAndSelect('matchingHistory.user', 'user')
       .leftJoinAndSelect('matchingHistory.matchedUser', 'matchedUser')
-      .getMany();
+      .orderBy('matchingHistory.createdAt', 'DESC')
+      .take(take)
+      .skip(skip)
+      .getManyAndCount();
 
     return matchingHistories;
   }

--- a/src/matching-histories/matching-histories.service.ts
+++ b/src/matching-histories/matching-histories.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { MatchingHistoryFormDTO } from './dto/matching-history-form.dto';
 import { UserDTO } from 'src/users/dto/user.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -6,6 +6,7 @@ import { MatchingHistoryEntity } from './matching-histories.entity';
 import { Repository } from 'typeorm';
 import { UsersService } from 'src/users/users.service';
 import { DEFAULT_SKIP, DEFAULT_TAKE } from 'src/constants/page';
+import { matchingHistoryExceptionMessage } from 'src/constants/exceptionMessage';
 
 @Injectable()
 export class MatchingHistoriesService {
@@ -45,5 +46,22 @@ export class MatchingHistoriesService {
       .getManyAndCount();
 
     return matchingHistories;
+  }
+
+  async delete(historyId: string) {
+    const targetMatchingHistory =
+      await this.matchingHistoryRepository.findOneBy({
+        id: historyId,
+      });
+
+    if (!targetMatchingHistory) {
+      throw new NotFoundException(
+        matchingHistoryExceptionMessage.DOES_NOT_EXIST_MATCHING_HISTORY,
+      );
+    }
+
+    await this.matchingHistoryRepository.softDelete(historyId);
+
+    return { message: '삭제되었습니다.' };
   }
 }

--- a/src/matching-histories/matching-histories.service.ts
+++ b/src/matching-histories/matching-histories.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { MatchingHistoryFormDTO } from './dto/matching-history-form.dto';
+import { UserDTO } from 'src/users/dto/user.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MatchingHistoryEntity } from './matching-histories.entity';
+import { Repository } from 'typeorm';
+import { UsersService } from 'src/users/users.service';
+
+@Injectable()
+export class MatchingHistoriesService {
+  constructor(
+    @InjectRepository(MatchingHistoryEntity)
+    private readonly matchingHistoryRepository: Repository<MatchingHistoryEntity>,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async create(
+    matchingHistoryForm: MatchingHistoryFormDTO,
+    currentUser: UserDTO,
+  ) {
+    const { matchedUserId, matchTime } = matchingHistoryForm;
+
+    const matchedUser = await this.usersService.findUserById(matchedUserId);
+
+    const newMatchingHistory = this.matchingHistoryRepository.create({
+      user: currentUser,
+      matchedUser,
+      matchTime,
+    });
+
+    await this.matchingHistoryRepository.save(newMatchingHistory);
+
+    return newMatchingHistory;
+  }
+}

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -24,6 +24,7 @@ import {
 } from 'typeorm';
 import { UserToTermsAgreementEntity } from 'src/user-to-terms-agreements/user-to-terms-agreements.entity';
 import { UserToBadgeEntity } from 'src/user-to-badges/user-to-badges.entity';
+import { MatchingHistoryEntity } from 'src/matching-histories/matching-histories.entity';
 
 @Index('email', ['email'], { unique: true })
 @Entity({
@@ -135,4 +136,14 @@ export class UserEntity {
     cascade: true,
   })
   userToBadges: UserToBadgeEntity[];
+
+  @ApiProperty()
+  @OneToMany(
+    () => MatchingHistoryEntity,
+    (matchingHistory: MatchingHistoryEntity) => matchingHistory.user,
+    {
+      cascade: true,
+    },
+  )
+  matchingHistories: MatchingHistoryEntity[];
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #129 

<br />

## 🗒 작업 목록

- [x] 매칭 이력 API 개발 (생성, 조회, 삭제)
- [x] 활동 API 매칭 횟수 추가
- [x] swagger 적용

<br />

## 🧐 PR Point

- 매칭 이력으로 사용자의 매칭 횟수를 조회할 수 있습니다.
- 피드백의 경우 매칭 이력 테이블과 관계지어 관리할 예정입니다.
    - 피드백 데이터에는 어떤 매칭을 누구와 했는지에 대한 데이터를 관리하기 위해 위와 같이 구성하였습니다.
- 프론트에선 매칭 이력 API 중 생성만 사용하면 될 것으로 예상됩니다.
    - 매칭 종료 후 매칭 이력 생성 API 호출
    - 활동 관련 API 호출 시 내부 로직에서 매칭 횟수 계산

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

<img width="1457" alt="image" src="https://github.com/user-attachments/assets/02d01d1d-1cb8-4342-a48a-dd4702a68feb">
<img width="930" alt="image" src="https://github.com/user-attachments/assets/37827bf5-e493-433d-b05f-cb339afd0fc3">



<br />

## 📚 참고

- https://www.erdcloud.com/d/Akaf86uDo45j6KhuY

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
