### PR TITLE
사용자별 일기 검색 이슈

### DIFF
--- a/src/diaries/diaries.service.ts
+++ b/src/diaries/diaries.service.ts
@@ -98,16 +98,22 @@ export class DiariesService {
           );
 
     if (searchKeyword) {
-      selectDiaryInstance
-        .where(`${tableAliasInfo.diaryAuthor}.username ILIKE :searchKeyword`, {
-          searchKeyword: `%${searchKeyword}%`,
-        })
-        .orWhere(`${tableAliasInfo.diary}.title ILIKE :searchKeyword`, {
-          searchKeyword: `%${searchKeyword}%`,
-        })
-        .orWhere(`${tableAliasInfo.diary}.content ILIKE :searchKeyword`, {
-          searchKeyword: `%${searchKeyword}%`,
-        });
+      selectDiaryInstance.andWhere(
+        new Brackets((qb) => {
+          qb.where(
+            `${tableAliasInfo.diaryAuthor}.username ILIKE :searchKeyword`,
+            {
+              searchKeyword: `%${searchKeyword}%`,
+            },
+          )
+            .orWhere(`${tableAliasInfo.diary}.title ILIKE :searchKeyword`, {
+              searchKeyword: `%${searchKeyword}%`,
+            })
+            .orWhere(`${tableAliasInfo.diary}.content ILIKE :searchKeyword`, {
+              searchKeyword: `%${searchKeyword}%`,
+            });
+        }),
+      );
     }
 
     if (sortByConverter[sortBy] === undefined)
@@ -171,16 +177,22 @@ export class DiariesService {
       );
 
     if (searchKeyword) {
-      diariesByUsername
-        .where(`${tableAliasInfo.diaryAuthor}.username ILIKE :searchKeyword`, {
-          searchKeyword: `%${searchKeyword}%`,
-        })
-        .orWhere(`${tableAliasInfo.diary}.title ILIKE :searchKeyword`, {
-          searchKeyword: `%${searchKeyword}%`,
-        })
-        .orWhere(`${tableAliasInfo.diary}.content ILIKE :searchKeyword`, {
-          searchKeyword: `%${searchKeyword}%`,
-        });
+      diariesByUsername.andWhere(
+        new Brackets((qb) => {
+          qb.where(
+            `${tableAliasInfo.diaryAuthor}.username ILIKE :searchKeyword`,
+            {
+              searchKeyword: `%${searchKeyword}%`,
+            },
+          )
+            .orWhere(`${tableAliasInfo.diary}.title ILIKE :searchKeyword`, {
+              searchKeyword: `%${searchKeyword}%`,
+            })
+            .orWhere(`${tableAliasInfo.diary}.content ILIKE :searchKeyword`, {
+              searchKeyword: `%${searchKeyword}%`,
+            });
+        }),
+      );
     }
 
     if (sortByConverter[sortBy] === undefined)


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #295

<br />

## 🗒 작업 목록

- [x] username 별 일기 검색 API Where 메소드 수정

<br />

## 🧐 PR Point

- typeorm의 query builder객체에서 where 메소드를 두번 하는 경우 마지막 where 메소드로 덮어지는 이슈로 인한 버그 발생
- 두번째 where 메소드가 실행되는 로직을 andWhere 메소드로 변경 후 typeOrm에서 제공하는 Brackets 객체를 활용하여 유저네임, 검색어에 대한 where 조건을 적용하였습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
