### PR TITLE
로컬 실행 docker compose 매뉴얼 작성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# app
+NODE_ENV=development
+PORT=5000
+
+# swagger 인증
+ADMIN_USER=your_swagger_username
+ADMIN_PASSWORD=your_swagger_password
+
+SECRET_KEY=...asdasf
+
+DB_NAME=postgres # 아래 db에서 설정한 POSTGRES_DB
+DB_USERNAME=your_db_username # 아래 db에서 설정한 POSTGRES_USER
+DB_PASSWORD=your_db_password # 아래 db에서 설정한 POSTGRES_PASSWORD
+DB_PORT=5432 # postgres 기본 포트 
+DB_HOST=postgres
+# CORS_ORIGIN_LIST=https://www.a-daily-diary.com
+
+# db
+POSTGRES_DB=postgres
+POSTGRES_USER=your_db_username
+POSTGRES_PASSWORD=your_db_password
+TZ=Asia/Seoul
+PGTZ=Asia/Seoul
+
+# AWS
+AWS_S3_ACCESS_KEY=your_access_key
+AWS_S3_SECRET_KEY=your_secret_key
+AWS_S3_REGION=ap-northeast-2
+AWS_S3_BUCKET_NAME=your_bucket_name
+
+# admin account
+ADMIN_EMAIL=your_admin_account_email # 서비스 구동 시 자동 생성
+
+# # SMTP
+SMTP_HOST=your_smtp_host
+SMTP_PORT=587
+SMTP_EMAIL=your_smtp_email
+SMTP_PASSWORD=your_smtp_password

--- a/README.md
+++ b/README.md
@@ -1,31 +1,3 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="200" alt="Nest Logo" /></a>
-</p>
-
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
-
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
-
-## Description
-
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
 ## Installation
 
 ```bash
@@ -45,29 +17,68 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
-## Test
+## 로컬 개발 및 배포(Docker Compose)
+
+> ⚠️ **아래 매뉴얼을 따라하기 전에, 반드시 Docker가 설치되어 있어야 합니다.**
+>
+> - 각 운영체제(Windows, macOS, Linux)에 맞는 [Docker Desktop](https://www.docker.com/products/docker-desktop/)을 설치하세요.
+> - 설치 방법은 [공식 매뉴얼](https://docs.docker.com/get-docker/)을 참고하세요.
+
+### 1. 환경 변수 설정
+
+1. `.env.example` 파일을 참고하여 `.env` 파일을 프로젝트 루트에 복사/생성합니다.
+2. 각 항목을 실제 환경에 맞게 수정합니다.
 
 ```bash
-# unit tests
-$ npm run test
-
-# e2e tests
-$ npm run test:e2e
-
-# test coverage
-$ npm run test:cov
+cp .env.example .env
 ```
 
-## Support
+- 주요 환경변수 예시:
+  - `DB_HOST`: DB 컨테이너 서비스명 (docker-compose.yml의 postgres 서비스명과 일치)
+  - `DB_PORT`: 5432 (컨테이너 내부 포트)
+  - `DB_USERNAME`, `DB_PASSWORD`, `DB_DATABASE`: Postgres 접속 정보
 
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+### 2. Docker 이미지 빌드 및 컨테이너 실행
 
-## Stay in touch
+#### 컨테이너 실행 (백그라운드)
 
-- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
+- 가장 기본적인 실행 방법:
 
-## License
+```bash
+docker-compose up -d
+```
 
-Nest is [MIT licensed](LICENSE).
+- 위 명령어로 컨테이너가 백그라운드에서 실행됩니다.
+- 서버는 기본적으로 `localhost:5000`에서 접근 가능합니다.
+- 이미 5000 포트를 사용 중이면, docker-compose.yml에서 콜론 앞 포트 번호를 변경하세요.
+
+#### 코드 수정 시
+
+- 코드가 변경된 경우에는 이미지를 새로 빌드해야 변경사항이 반영됩니다.
+- 아래와 같이 `--build` 옵션을 추가해 실행하세요:
+
+```bash
+docker-compose up -d --build
+```
+
+- 기존 컨테이너가 실행 중이라면, `docker-compose down`으로 중지 후 다시 실행해도 됩니다.
+
+### 3. DB 데이터 유지
+
+- 컨테이너 종료 시에도 DB 데이터를 유지하고 싶다면, docker-compose.yml의 `volumes` 주석을 해제하세요.
+  ```yaml
+  # volumes:
+  #   - ./db-data:/var/lib/postgresql/data
+  ```
+
+### 4. 포트 및 서비스명 주의사항
+
+- `add-be` 컨테이너는 5000번 포트(혹은 변경한 포트)로 외부에 노출됩니다.
+- `postgres` 컨테이너는 15432(호스트):5432(컨테이너)로 매핑되어 있습니다.
+- 컨테이너 내부에서 DB에 접근할 때는 항상 `DB_HOST=postgres`와 `DB_PORT=5432`로 설정해야 합니다.
+
+### 5. 기타
+
+- 컨테이너 로그 확인: `docker-compose logs -f`
+- 컨테이너 중지: `docker-compose down`
+- 컨테이너 강제 재시작: `docker-compose restart`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,13 @@ version: '3.5'
 services:
   add-be:
     container_name: add-be
-    image: woosang0430/add-be:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
     env_file:
       - ./.env
     ports:
+      # 이미 5000 포트를 사용하고 있는 경우 콜론 앞 포트 번호 변경
       - 5000:5000
     networks:
       - add-network
@@ -19,12 +22,14 @@ services:
     env_file:
       - ./.env
     ports:
-      - 5432:5432
+      # 이미 15432 포트를 사용하고 있는 경우 콜론 앞 포트 번호 변경
+      - 15432:5432
     networks:
       - add-network
     restart: always
-    volumes:
-      - ./db-data:/var/lib/postgresql/data
+    # 컨테이너 종료 시에도 데이터를 유지하고 싶은 경우 아래 주석 해제
+    # volumes:
+    #   - ./db-data:/var/lib/postgresql/data
 networks:
   add-network:
     driver: bridge

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,4 @@
-import { Body, Controller, Get, Post, UseFilters } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { Controller, Get, UseFilters } from '@nestjs/common';
 import { AppService } from './app.service';
 import { HttpApiExceptionFilter } from './common/exceptions/http-api-exceptions.filter';
 
@@ -11,13 +10,5 @@ export class AppController {
   @Get()
   getHello(): string {
     return this.appService.getHello();
-  }
-
-  @Post()
-  @ApiOperation({
-    summary: '약관동의, 뱃지 데이터 설정 API',
-  })
-  setInitDataSet(@Body() adminKey: { adminKey: string }) {
-    return this.appService.setInitDataSet(adminKey);
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -14,12 +14,7 @@ export class AppService {
   getHello(): string {
     return 'Hello World!';
   }
-
-  async setInitDataSet(adminKey: { adminKey: string }) {
-    const correctAdminToken = process.env.ADMIN_KEY;
-    if (adminKey.adminKey !== correctAdminToken)
-      throw new BadRequestException(exceptionMessage.INCORRECT_KEY);
-
+  async setInitDataSet() {
     const adminUser = await this.usersService.generateAdminAccount();
 
     if (adminUser.isAdmin === false)

--- a/src/badges/badges.service.ts
+++ b/src/badges/badges.service.ts
@@ -165,6 +165,9 @@ export class BadgesService {
   }
 
   async setInitDataSetForBadges(requestUser: UserDTO) {
+    const count = await this.badgeRepository.count();
+    if (count > 0) return true; // 이미 있으면 무시
+
     try {
       await this.createBadge(requestUser, steady0Badge);
       await this.createBadge(requestUser, steady1Badge);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { AppModule } from './app.module';
 import { HttpApiExceptionFilter } from './common/exceptions/http-api-exceptions.filter';
 import { SuccessInterceptor } from './common/interceptors/success.interceptor';
+import { AppService } from './app.service';
 
 class Application {
   private logger = new Logger(Application.name);
@@ -95,6 +96,18 @@ class Application {
 
   async bootstrap() {
     await this.setUpGlobalMiddleware();
+
+    // 데이터 시드 자동 실행
+    const appService = this.server.get(AppService);
+    try {
+      await appService.setInitDataSet();
+
+      console.log('데이터 시드 자동 실행 완료');
+    } catch (e) {
+      // 이미 데이터가 있거나 에러가 발생해도 무시하고 계속 진행
+      console.log('Seed error:', e.message);
+    }
+
     await this.server.listen(this.PORT);
   }
 

--- a/src/terms-agreements/terms-agreements.service.ts
+++ b/src/terms-agreements/terms-agreements.service.ts
@@ -101,6 +101,9 @@ export class TermsAgreementsService {
   }
 
   async setInitDataSetForTermsAgreements() {
+    const count = await this.termsAgreementRepository.count();
+    if (count > 0) return true; // 이미 있으면 무시
+
     try {
       await this.createTermsAgreement(serviceTermsAgreementDataSet);
       await this.createTermsAgreement(privacyTermsAgreementDataSet);


### PR DESCRIPTION
## 🔗 연관된 이슈

- close #142

<br />

## 🗒 작업 목록

- [x] Docker Compose를 이용한 로컬 개발 및 배포 매뉴얼(README.md) 추가
- [x] 예시 환경변수 파일(.env.example) 추가
- [x] add-be 서비스의 이미지 빌드 방식 변경 (docker-compose.yml)
- [x] postgres 서비스 이름 및 포트 번호 조정 (docker-compose.yml)
- [x] 데이터 시드 자동 실행 기능 추가 및 관련 코드 정리

<br />

## 🧐 PR Point

- 로컬 환경에서 누구나 쉽게 백엔드 서버 환경을 구성할 수 있도록 Docker Compose 매뉴얼을 작성했습니다.
- add-be 서비스가 레지스트리 이미지가 아닌, 로컬에서 직접 빌드하도록 변경했습니다.
- DB 컨테이너 이름 및 포트가 변경되었으니, 환경변수(DB_HOST, DB_PORT) 설정에 주의해야 합니다.
- 서버 실행 시 데이터 시드가 자동으로 동작하며, 이미 데이터가 있으면 무시하도록 처리했습니다.

<br />

## 💥 Trouble Shooting

- 해당 작업을 하던 중 발생했던 문제에 대해 작성해주세요.

<br />

## 📸 스크린샷 / 피그마 링크

- 내용을 입력해주세요.

<br />

## 📚 참고

- 참고한 내용 또는 링크를 입력해주세요.

<br />

## ✅ PR Submit 전 체크리스트

- [x] Merge 하는 브랜치는 `main` 브랜치가 아닙니다.
- [x] 코드에 크리티컬한 `error` 또는 `warning`이 존재하지 않습니다.
- [x] 불필요한 `console`이 존재하지 않습니다.
